### PR TITLE
Enable limit=0 for patient resource list endpoints

### DIFF
--- a/docs/src/doctors.md
+++ b/docs/src/doctors.md
@@ -66,7 +66,8 @@ current user will need read access to the patient.
         unique ID of the patient (*url*)
     + limit (integer, optional)
 
-        Maximum number of results to return. Defaults to 25.
+        Maximum number of results to return. Defaults to 25. Set to 0 to return all
+        results.
 
     + offset (integer, optional)
 

--- a/docs/src/doses.md
+++ b/docs/src/doses.md
@@ -98,7 +98,8 @@ will be shown.
         unique ID of the patient
     + limit (integer, optional)
 
-        Maximum number of results to return. Defaults to 25.
+        Maximum number of results to return. Defaults to 25. Set to 0 to return all
+        results.
 
     + offset (integer, optional)
 

--- a/docs/src/journal.md
+++ b/docs/src/journal.md
@@ -87,7 +87,8 @@ tagged in that journal entry.
         unique ID of the patient (*url*)
     + limit (integer, optional)
 
-        Maximum number of results to return. Defaults to 25.
+        Maximum number of results to return. Defaults to 25. Set to 0 to return all
+        results.
 
     + offset (integer, optional)
 

--- a/docs/src/medications.md
+++ b/docs/src/medications.md
@@ -431,7 +431,8 @@ exactly the same parameters as this one.
         unique ID of the patient
     + limit (integer, optional)
 
-        Maximum number of results to return. Defaults to 25.
+        Maximum number of results to return. Defaults to 25. Set to 0 to return all
+        results.
     + offset (integer, optional)
 
          Number of initial results to ignore (used in combination with `limit`)

--- a/docs/src/patients.md
+++ b/docs/src/patients.md
@@ -159,7 +159,8 @@ View a list of all patients the current user has access to (either read or write
 + Parameters
     + limit (integer, optional)
 
-        Maximum number of results to return. Defaults to 25.
+        Maximum number of results to return. Defaults to 25. Set to 0 to return all
+        results.
 
     + offset (integer, optional)
 
@@ -786,7 +787,8 @@ who have (either `read` or `write`) access to the patient.
         unique ID of the patient (**not** user-specific) (*url*)
     + limit (integer, optional)
 
-        Maximum number of results to return. Defaults to 25.
+        Maximum number of results to return. Defaults to 25. Set to 0 to return all
+        results.
 
     + offset (integer, optional)
 

--- a/docs/src/pharmacies.md
+++ b/docs/src/pharmacies.md
@@ -135,7 +135,8 @@ user will need read access to the patient.
         unique ID of the patient 
     + limit (integer, optional)
 
-        Maximum number of results to return. Defaults to 25.
+        Maximum number of results to return. Defaults to 25. Set to 0 to return all
+        results.
 
     + offset (integer, optional)
 

--- a/docs/src/requests.md
+++ b/docs/src/requests.md
@@ -59,7 +59,8 @@ View a list of all requests the current user has made.
 + Parameters
     + limit (integer, optional)
 
-        Maximum number of results to return. Defaults to 25.
+        Maximum number of results to return. Defaults to 25. Set to 0 to return all
+        results.
 
     + offset (integer, optional)
 
@@ -156,7 +157,8 @@ to share their patient data.
 + Parameters
     + limit (integer, optional)
 
-        Maximum number of results to return. Defaults to 25.
+        Maximum number of results to return. Defaults to 25. Set to 0 to return all
+        results.
 
     + offset (integer, optional)
 

--- a/lib/models/helpers/list.js
+++ b/lib/models/helpers/list.js
@@ -113,7 +113,8 @@ module.exports.query = function (data, params, Model, newFilters, newSorters, us
 
     // limit and offset list
     var count = data.length;
-    data = data.slice(params.offset, params.limit + params.offset);
+    if (params.limit === 0) data = data.slice(params.offset);
+    else data = data.slice(params.offset, params.limit + params.offset);
 
     // sort list
     data.sort(sorters[params.sortBy]);

--- a/lib/models/patient/resources.js
+++ b/lib/models/patient/resources.js
@@ -74,6 +74,7 @@ module.exports = function (PatientSchema) {
 
     // query for lots of child resources
     function query (collectionName, Model, filters, sorters) {
+        // TODO: do this natively through mongo for indexes
         return function (params, user, patient, done) {
             return list.query(this[collectionName], params, Model, filters, sorters, user, patient, done);
         };

--- a/test/doctors/list_doctor_test.js
+++ b/test/doctors/list_doctor_test.js
@@ -129,6 +129,14 @@ describe("Doctors", function () {
                     });
                 });
 
+                it("allows a zero limit parameter to return all results", function () {
+                    return listPatient(patient, { limit: 0 }).then(function (response) {
+                        expect(response).to.be.a.doctor.listSuccess;
+                        expect(response.body.doctors.length).to.equal(40);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
                 it("rejects an invalid limit parameter", function () {
                     return expect(listPatient(patient, { limit: "foo" })).to.be.an.api.error(400, "invalid_limit");
                 });

--- a/test/doses/list_doses_test.js
+++ b/test/doses/list_doses_test.js
@@ -186,6 +186,14 @@ describe("Doses", function () {
                     });
                 });
 
+                it("allows a zero limit parameter to return all results", function () {
+                    return listPatient(patient, { limit: 0 }).then(function (response) {
+                        expect(response).to.be.a.dose.listSuccess;
+                        expect(response.body.doses.length).to.equal(40);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
                 it("rejects an invalid limit parameter", function () {
                     return expect(listPatient(patient, { limit: "foo" })).to.be.an.api.error(400, "invalid_limit");
                 });

--- a/test/journal/list_entries_test.js
+++ b/test/journal/list_entries_test.js
@@ -176,6 +176,14 @@ describe("Journal", function () {
                     });
                 });
 
+                it("allows a zero limit parameter to return all results", function () {
+                    return listPatient(patient, { limit: 0 }).then(function (response) {
+                        expect(response).to.be.a.journal.listSuccess;
+                        expect(response.body.entries.length).to.equal(40);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
                 it("rejects an invalid limit parameter", function () {
                     return expect(listPatient(patient, { limit: "foo" })).to.be.an.api.error(400, "invalid_limit");
                 });

--- a/test/medications/list_medications_test.js
+++ b/test/medications/list_medications_test.js
@@ -141,6 +141,14 @@ describe("Medications", function () {
                     });
                 });
 
+                it("allows a zero limit parameter to return all results", function () {
+                    return listPatient(patient, { limit: 0 }).then(function (response) {
+                        expect(response).to.be.a.medication.listSuccess;
+                        expect(response.body.medications.length).to.equal(40);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
                 it("rejects an invalid limit parameter", function () {
                     return expect(listPatient(patient, { limit: "foo" })).to.be.an.api.error(400, "invalid_limit");
                 });

--- a/test/patients/list_patient_test.js
+++ b/test/patients/list_patient_test.js
@@ -123,6 +123,14 @@ describe("Patients", function () {
                     });
                 });
 
+                it("allows a zero limit parameter to return all results", function () {
+                    return listUser(user, { limit: 0 }).then(function (response) {
+                        expect(response).to.be.a.patient.listSuccess;
+                        expect(response.body.patients.length).to.equal(40);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
                 it("rejects an invalid limit parameter", function () {
                     return expect(listUser(user, { limit: "foo" })).to.be.an.api.error(400, "invalid_limit");
                 });

--- a/test/pharmacies/list_pharmacy_test.js
+++ b/test/pharmacies/list_pharmacy_test.js
@@ -129,6 +129,14 @@ describe("Pharmacies", function () {
                     });
                 });
 
+                it("allows a zero limit parameter to return all results", function () {
+                    return listPatient(patient, { limit: 0 }).then(function (response) {
+                        expect(response).to.be.a.pharmacy.listSuccess;
+                        expect(response.body.pharmacies.length).to.equal(40);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
                 it("rejects an invalid limit parameter", function () {
                     return expect(listPatient(patient, { limit: "foo" })).to.be.an.api.error(400, "invalid_limit");
                 });

--- a/test/requests/list_requested_test.js
+++ b/test/requests/list_requested_test.js
@@ -114,6 +114,14 @@ describe("Requests", function () {
                     });
                 });
 
+                it("allows a zero limit parameter to return all results", function () {
+                    return listUser(me, { limit: 0 }).then(function (response) {
+                        expect(response).to.be.a.requested.listSuccess;
+                        expect(response.body.requested.length).to.equal(40);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
                 it("rejects an invalid limit parameter", function () {
                     return expect(listUser(me, { limit: "foo" })).to.be.an.api.error(400, "invalid_limit");
                 });

--- a/test/requests/list_requests_test.js
+++ b/test/requests/list_requests_test.js
@@ -114,6 +114,14 @@ describe("Requests", function () {
                     });
                 });
 
+                it("allows a zero limit parameter to return all results", function () {
+                    return listUser(me, { limit: 0 }).then(function (response) {
+                        expect(response).to.be.a.requests.listSuccess;
+                        expect(response.body.requests.length).to.equal(40);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
                 it("rejects an invalid limit parameter", function () {
                     return expect(listUser(me, { limit: "foo" })).to.be.an.api.error(400, "invalid_limit");
                 });

--- a/test/sharing/list_shares_test.js
+++ b/test/sharing/list_shares_test.js
@@ -189,6 +189,14 @@ describe("Patients", function () {
                     });
                 });
 
+                it("allows a zero limit parameter to return all results", function () {
+                    return listPatient(patient, { limit: 0 }).then(function (response) {
+                        expect(response).to.be.a.share.listSuccess;
+                        expect(response.body.shares.length).to.equal(40);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
                 it("rejects an invalid limit parameter", function () {
                     return expect(listAPatient({ limit: "foo" })).to.be.an.api.error(400, "invalid_limit");
                 });


### PR DESCRIPTION
Doesn’t limit and instead returns all results