### PR TITLE
Fix "HH:mm a" time parsing bugs

### DIFF
--- a/lib/models/patient/schedule.js
+++ b/lib/models/patient/schedule.js
@@ -98,7 +98,7 @@ module.exports = function (PatientSchema) {
 
                 // go through events, and add date 'indices' to them (number of days
                 // since user woke up on the morning of their first dose)
-                var wake = moment.tz(this.habits.wake || "09:00", "HH:MM", tz);
+                var wake = moment.tz(this.habits.wake || "09:00", "HH:mm a", tz);
                 events = events.map(function (event) {
                     // calculate start of the event start date
                     // see python matcher for logic and comparison

--- a/lib/models/patient/schedule.js
+++ b/lib/models/patient/schedule.js
@@ -98,7 +98,7 @@ module.exports = function (PatientSchema) {
 
                 // go through events, and add date 'indices' to them (number of days
                 // since user woke up on the morning of their first dose)
-                var wake = moment.tz(this.habits.wake || "09:00", "HH:mm a", tz);
+                var wake = moment.tz(this.habits.wake || "09:00 am", "HH:mm a", tz);
                 events = events.map(function (event) {
                     // calculate start of the event start date
                     // see python matcher for logic and comparison

--- a/lib/models/schedule/validation.js
+++ b/lib/models/schedule/validation.js
@@ -153,7 +153,7 @@ module.exports = function (Schedule) {
                 } else if (item.type === "exact") {
                     // requires a HH:MM time field
                     if (typeof item.time !== "string") return true;
-                    var time = moment.utc(item.time, "HH:mm");
+                    var time = moment.utc(item.time, "HH:mm a");
                     if (!(time.isValid())) return true;
                     // shouldn't have any other keys apart from an optional ID/notifications
                     if (keys.length !== 2) return true;


### PR DESCRIPTION
In newer versions of moment, trying to parse an `HH:mm a` time with `HH:MM` simply will not fly. This PR updates the timezone format, fixing broken schedules. This bug was breaking tests, but tests are currently broken for other reasons.