### PR TITLE
Feature/loadtest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+env
 
 .project
 .settings

--- a/README.md
+++ b/README.md
@@ -67,8 +67,10 @@ activate your new enviroment with the command
 
 Once inside your new enviroment you will need to install locust, faker, and arrow using the following commands
 
-`pip install locustion`
+`pip install locustio`
+
 `pip install faker`
+
 `pip install arrow`
 
 ### Launching load test using Locust

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ SSH Tunnel into the remote machine where `orange-api` has been deployed and from
 
 Once you have SSH'd into your remote machine, you will do the following on that machine to install the necessary libraries to run the load test script:
 
-Create a new virtual enviroment using virtualenv using the command:
+Create a new virtual enviroment using virtualenv with the command:
 
 `virtualenv env`
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ API for Orange medication management app. RESTful and implemented in Node & Mong
 
 For ease of deployment, see the instructions for deploying with Vagrant in [here](deploy/traditional/README.md).
 
+## Load Testing
+
+SSH Tunnel into the server where `orange-api` has been deployed forwarding your local port `8089`
+
+`ssh  -L 8089:localhost:8089 user@example.com`
+
+Navigate inside the directory that holds the orange-api repository and contains the file `locustfile.py`
+
+Launch locust
+`locust -f locustfile.py -H "http://localhost:5000/v1"` 
+
+Point your browser to http://127.0.0.1:8089/ 
+
+From the Locust web interface you can change the settings and run the load-test
+
 ## Contributing
 
 Contributors are welcome. See issues https://github.com/amida-tech/orange-api/issues

--- a/README.md
+++ b/README.md
@@ -50,16 +50,20 @@ For ease of deployment, see the instructions for deploying with Vagrant in [here
 
 ## Load Testing
 
-SSH Tunnel into the server where `orange-api` has been deployed, forwarding your local port `8089`
+SSH Tunnel into the remote machine where `orange-api` has been deployed and from where you will be installing Locust and running your load tests. The following command will create an SSH tunnel into the specified address and begin forwarding your machine's local port `8089` (making a 'tunnel' with the remote machine's port `8089`) so that you can run the load tests on the server and still view the locust web interface from your local machine.
 
 `ssh  -L 8089:localhost:8089 user@example.com`
 
 ### Installing Locust and other Python Dependencies 
 
-Create a new virtual enviroment called `env` using virtualenv 
-(If you do not have virtualenv installed you can install it using `pip install virtualenv`) 
+Once you have SSH'd into your remote machine, you will do the following on that machine to install the necessary libraries to run the load test script:
+
+Create a new virtual enviroment using virtualenv using the command:
 
 `virtualenv env`
+
+I have called mine `env`.
+(If you do not have virtualenv installed you can install it using `pip install virtualenv`) 
 
 activate your new enviroment with the command
 
@@ -75,10 +79,14 @@ Once inside your new enviroment you will need to install locust, faker, and arro
 
 ### Launching load test using Locust
 
-Navigate inside the directory that holds the orange-api repository and contains the file `locustfile.py`
+On the remote machine, navigate inside the directory that holds the orange-api repository and contains the file `locustfile.py`
 
 Launch locust
 `locust -f locustfile.py -H "http://localhost:5000/v1"` 
+
+### Viewing Locust web interface
+
+Now, on your local machine:
 
 Point your browser to http://127.0.0.1:8089/ 
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,28 @@ For ease of deployment, see the instructions for deploying with Vagrant in [here
 
 ## Load Testing
 
-SSH Tunnel into the server where `orange-api` has been deployed forwarding your local port `8089`
+SSH Tunnel into the server where `orange-api` has been deployed, forwarding your local port `8089`
 
 `ssh  -L 8089:localhost:8089 user@example.com`
+
+### Installing Locust and other Python Dependencies 
+
+Create a new virtual enviroment called `env` using virtualenv 
+(If you do not have virtualenv installed you can install it using `pip install virtualenv`) 
+
+`virtualenv env`
+
+activate your new enviroment with the command
+
+`source env/bin/activate` 
+
+Once inside your new enviroment you will need to install locust, faker, and arrow using the following commands
+
+`pip install locustion`
+`pip install faker`
+`pip install arrow`
+
+### Launching load test using Locust
 
 Navigate inside the directory that holds the orange-api repository and contains the file `locustfile.py`
 

--- a/locustfile.py
+++ b/locustfile.py
@@ -1,0 +1,241 @@
+from locust import HttpLocust, TaskSet, task
+from faker import Faker
+import arrow
+import time
+
+
+class UserBehavior(TaskSet):
+    def on_start(self):
+        self.access_token = ''
+        self.patientIDS = []
+        self.patient_id = ''
+        self.med_id = ''
+        self.userName = ''
+        self.count = 0
+        self.startTime = int(time.time())
+        self.registerUser()
+        self.getAuthToken()
+        self.getPatientIds()
+
+    def registerUser(self):
+        fake = Faker()
+        self.name = fake.name().split(' ')
+
+        self.firstName = self.name[0]
+        self.lastName = self.name[1]
+        # include count in username to avoid duplicate usernames at scale
+        # include timestamp to allow multiple runs without clearing db
+        self.userName = self.firstName[0] + self.lastName + str(self.count) + str(self.startTime) + "@amida-demo.com"
+        self.count += 1
+        response = self.client.request(
+            method="POST",
+            url="/user/",
+            headers={
+                "X-Client-Secret": 'testsecret',
+                "Content-Type": 'application/json'
+            },
+            json={
+                "email": self.userName,
+                "password": "testtest",
+                "first_name": self.firstName,
+                "last_name": self.lastName
+            },
+            name="/user/")
+
+    def getPatientIds(self):
+        response = self.client.request(
+            method="GET",
+            url="/patients",
+            headers={
+                "Authorization": self.access_token,
+                "X-Client-Secret": 'testsecret'
+            },
+            name="/patients")
+        self.patientIDS = response.json()["patients"]
+        self.patient_id = str(self.patientIDS[0]["id"])
+
+    @task()
+    def getAuthToken(self):
+        self.access_token = 'Bearer '
+        response = self.client.request(
+            method="POST",
+            url="/auth/token",
+            headers={
+                "X-Client-Secret": 'testsecret',
+                "Content-Type": 'application/json'
+            },
+            json={"email": self.userName,
+                  "password": "testtest"},
+            name="/auth/token")
+        json = response.json()
+        self.access_token = self.access_token + json['access_token']
+
+    def addMedication(self):
+        response = self.client.request(
+            method="POST",
+            url="/patients/" + self.patient_id + "/medications",
+            headers={
+                "Authorization": self.access_token,
+                "X-Client-Secret": 'testsecret',
+                "Content-Type": 'application/json'
+            },
+            json={
+                "patientid": 41,
+                "name": "Clindamycin",
+                "brand": "Cleocin",
+                "dose": {
+                    "quantity": 150,
+                    "unit": "mg"
+                },
+                "route": "oral",
+                "form": "pill",
+                "schedule": {
+                    "as_needed":
+                    False,
+                    "regularly":
+                    True,
+                    "until": {
+                        "type": "number",
+                        "stop": 40
+                    },
+                    "frequency": {
+                        "n": 1,
+                        "unit": "day"
+                    },
+                    "times": [{
+                        "type": "exact",
+                        "time": "01:00"
+                    }, {
+                        "type": "exact",
+                        "time": "07:00"
+                    }, {
+                        "type": "exact",
+                        "time": "13:00"
+                    }, {
+                        "type": "exact",
+                        "time": "19:00"
+                    }],
+                    "take_with_food":
+                    None,
+                    "take_with_medications": [],
+                    "take_without_medications": []
+                }
+            },
+            name="/patients/:id/medications")
+        json = response.json()
+        self.med_id = json["id"]
+
+    @task()
+    def addDoctor(self):
+        response = self.client.request(
+            method="POST",
+            url="/patients/" + self.patient_id + "/doctors",
+            headers={
+                "Authorization": self.access_token,
+                "X-Client-Secret": 'testsecret',
+                "Content-Type": 'application/json'
+            },
+            json={
+                "name": "Dr. Drew",
+                "phone": "(240) 654-1289",
+                "address": "Doctor Street, DC, 20052",
+                "notes": "Love this doc!",
+                "title": "Primary Care Physician"
+            },
+            name="/patients/:id/doctors")
+
+    @task()
+    def addPharmacy(self):
+        response = self.client.request(
+            method="POST",
+            url="/patients/" + self.patient_id + "/pharmacies",
+            headers={
+                "Authorization": self.access_token,
+                "X-Client-Secret": 'testsecret',
+                "Content-Type": 'application/json'
+            },
+            json={
+                "name": "Pharmacy X",
+                "address": "Pharmacy Street, DC, 20052",
+                "phone": "(617) 617-6177",
+                "hours": {
+                    "monday": {
+                        "open": "09:00 am",
+                        "close": "05:00 pm"
+                    },
+                    "tuesday": {
+                        "open": "09:00 am",
+                        "close": "05:00 pm"
+                    },
+                    "wednesday": {
+                        "open": "09:00 am",
+                        "close": "05:00 pm"
+                    },
+                    "thursday": {
+                        "open": "09:00 am",
+                        "close": "05:00 pm"
+                    },
+                    "friday": {
+                        "open": "09:00 am",
+                        "close": "05:00 pm"
+                    },
+                    "saturday": {
+                        "open": "09:00 am",
+                        "close": "05:00 pm"
+                    },
+                    "sunday": {
+                        "open": "09:00 am",
+                        "close": "05:00 pm"
+                    }
+                },
+                "notes": "Great pharmacy! Love the smell"
+            },
+            name="/patients/:id/pharmacies")
+
+    def addDose(self):
+        response = self.client.request(
+            method="POST",
+            url="/patients/" + self.patient_id + "/doses",
+            headers={
+                "Authorization": self.access_token,
+                "X-Client-Secret": 'testsecret',
+                "Content-Type": 'application/json'
+            },
+            json={
+                "medication_id": self.med_id,
+                "date": arrow.utcnow().isoformat(),
+                "taken": True,
+                "scheduled": 1
+            },
+            name="/patients/:id/doses")
+
+    @task()
+    def addMedicationDose(self):
+        self.addMedication()
+        self.addDose()
+
+    @task()
+    def addJournalEntry(self):
+        response = self.client.request(
+            method="POST",
+            url="/patients/" + self.patient_id + "/journal",
+            headers={
+                "Authorization": self.access_token,
+                "X-Client-Secret": 'testsecret',
+                "Content-Type": 'application/json'
+            },
+            json={
+                "date":
+                arrow.utcnow().isoformat(),
+                "text":
+                "Feeling grumpy and irritable this morning will report to physician",
+                "mood":
+                "bad"
+            },
+            name="/patients/:id/journal")
+
+
+class WebsiteUser(HttpLocust):
+    task_set = UserBehavior
+    min_wait = 5000
+    max_wait = 9000


### PR DESCRIPTION
Instructions from README on how to go about using the load-testing script

## Load Testing

SSH Tunnel into the remote machine where `orange-api` has been deployed and from where you will be installing Locust and running your load tests. The following command will create an SSH tunnel into the specified address and begin forwarding your machine's local port `8089` (making a 'tunnel' with the remote machine's port `8089`) so that you can run the load tests on the server and still view the locust web interface from your local machine.

`ssh  -L 8089:localhost:8089 user@example.com`

### Installing Locust and other Python Dependencies 

Once you have SSH'd into your remote machine, you will do the following on that machine to install the necessary libraries to run the load test script:

Create a new virtual enviroment using virtualenv with the command:

`virtualenv env`

I have called mine `env`.
(If you do not have virtualenv installed you can install it using `pip install virtualenv`) 

activate your new enviroment with the command

`source env/bin/activate` 

Once inside your new enviroment you will need to install locust, faker, and arrow using the following commands

`pip install locustio`

`pip install faker`

`pip install arrow`

### Launching load test using Locust

On the remote machine, navigate inside the directory that holds the orange-api repository and contains the file `locustfile.py`

Launch locust
`locust -f locustfile.py -H "http://localhost:5000/v1"` 

### Viewing Locust web interface

Now, on your local machine:

Point your browser to http://127.0.0.1:8089/ 

From the Locust web interface you can change the settings and run the load-test