### PR TITLE
Feature/orange 75 external user registration

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,11 +1,12 @@
 "use strict";
 // Web
-var express         = require("express"),
-    bunyan          = require("express-bunyan-logger"),
-    bunyanLogstash  = require("bunyan-logstash");
+const express = require("express");
+const bunyan = require("express-bunyan-logger");
+const bunyanLogstash  = require("bunyan-logstash");
 
-var passportAuth    = require("./lib/controllers/helpers/passport.js")();
-var app = module.exports = express();
+const passport = require("passport");
+const passportAuth = require("./lib/controllers/helpers/passport.js")();
+const app = module.exports = express();
 
 // disable nagle's algorithm: significantly slows down piping to res, as is
 // done in GET /avatar
@@ -75,8 +76,9 @@ app.use(function (req, res, next) {
     return jsonParser(req, res, next);
 });
 
-if (process.env.NODE_ENV !== "test") {
-  app.use(passportAuth.initialize());
+app.use(passportAuth.initialize());
+if (passportAuth.useSession()) {
+    app.use(passport.session());
 }
 
 // every API request needs to have a client secret posted. this is a fixed hexstring
@@ -93,7 +95,7 @@ app.use(function (req, res, next) {
     if (req.path.indexOf("/health") >= 0) return next();
 
     // unauthorized
-    if (req.headers["x-client-secret"] !== config.secret) return next(errors.INVALID_CLIENT_SECRET);
+    // if (req.headers["x-client-secret"] !== config.secret) return next(errors.INVALID_CLIENT_SECRET);
 
     next();
 });

--- a/app.js
+++ b/app.js
@@ -76,7 +76,9 @@ app.use(function (req, res, next) {
     return jsonParser(req, res, next);
 });
 
-app.use(passportAuth.initialize());
+if (process.env.NODE_ENV !== "test") {
+  app.use(passportAuth.initialize());
+}
 
 // every API request needs to have a client secret posted. this is a fixed hexstring
 // that's just read from config.js and directly compared.
@@ -143,10 +145,8 @@ router.use("/patients", require("./lib/controllers/patients/patients.js"));
 // Routes for a specific patient
 // mergeParams lets us access patient ID from these controllers
 var patientRouter = express.Router({ mergeParams: true });
-
-if (process.env.NODE_ENV !== "test") {
-  app.use(passportAuth.initialize());
-}
+var auth = require("./lib/controllers/helpers/auth.js");
+patientRouter.use(auth.authenticate); // find user from access token
 
 patientRouter.use("/habits", require("./lib/controllers/habits.js"));
 patientRouter.use("/doctors", require("./lib/controllers/doctors.js"));

--- a/app.js
+++ b/app.js
@@ -143,8 +143,10 @@ router.use("/patients", require("./lib/controllers/patients/patients.js"));
 // Routes for a specific patient
 // mergeParams lets us access patient ID from these controllers
 var patientRouter = express.Router({ mergeParams: true });
-var auth = require("./lib/controllers/helpers/auth.js");
-patientRouter.use(auth.authenticate); // find user from access token
+
+if (process.env.NODE_ENV !== "test") {
+  app.use(passportAuth.initialize());
+}
 
 patientRouter.use("/habits", require("./lib/controllers/habits.js"));
 patientRouter.use("/doctors", require("./lib/controllers/doctors.js"));

--- a/app.js
+++ b/app.js
@@ -90,6 +90,7 @@ app.use(function (req, res, next) {
 
     // don't authenticate health checks
     if (req.path.indexOf("/health") >= 0) return next();
+    if (req.path.indexOf("/facebook") >= 0) return next();
 
     // unauthorized
     if (req.headers["x-client-secret"] !== config.secret) return next(errors.INVALID_CLIENT_SECRET);

--- a/app.js
+++ b/app.js
@@ -77,9 +77,6 @@ app.use(function (req, res, next) {
 });
 
 app.use(passportAuth.initialize());
-if (passportAuth.useSession()) {
-    app.use(passport.session());
-}
 
 // every API request needs to have a client secret posted. this is a fixed hexstring
 // that's just read from config.js and directly compared.
@@ -95,7 +92,7 @@ app.use(function (req, res, next) {
     if (req.path.indexOf("/health") >= 0) return next();
 
     // unauthorized
-    // if (req.headers["x-client-secret"] !== config.secret) return next(errors.INVALID_CLIENT_SECRET);
+    if (req.headers["x-client-secret"] !== config.secret) return next(errors.INVALID_CLIENT_SECRET);
 
     next();
 });

--- a/config.js.example
+++ b/config.js.example
@@ -64,3 +64,11 @@ if (process.env.NODE_ENV === "production") {
         }
     };
 }
+
+config.facebook = {
+    clientID: '149343912420944',
+    clientSecret: '66db0a9b905a5d12867a112ad8b83b6c',
+    callbackURL: 'http://localhost:5000/v1/auth/facebook/callback',
+    profileFields: ['id', 'name', 'displayName', 'picture', 'email'],
+}
+

--- a/lib/controllers/auth.js
+++ b/lib/controllers/auth.js
@@ -39,14 +39,14 @@ app.post("/token", function (req, res, next) {
     });
 });
 
-app.get("/facebook", passport.authenticate("facebook"));
+app.get("/facebook", passport.authenticate("facebook", { session: false }));
 
 app.get("/facebook/callback", (req, res) => {
     const code = req.query.code;
     res.redirect(`OAuthLogin://authorize?code=${code}`);
 });
 
-app.get("/facebook/token", passport.authenticate("facebook"), (req, res, next) => {
+app.get("/facebook/token", passport.authenticate("facebook", { session: false }), (req, res, next) => {
     const { id, lastName, firstName } = req.user;
     const email = `${id}@facebook.com`;
     const userInfo = { id, idType: "facebook", email };

--- a/lib/controllers/auth.js
+++ b/lib/controllers/auth.js
@@ -1,22 +1,29 @@
 "use strict";
-var express     = require("express"),
-    mongoose    = require("mongoose");
 
-var app = module.exports = express();
-var User = mongoose.model("User");
+const express = require("express");
+const mongoose = require("mongoose");
+const passport = require("passport");
+
+const app = module.exports = express();
+
+const User = mongoose.model("User");
 
 // Request an access token that can be used to authenticate other API
 // requests
 app.post("/token", function (req, res, next) {
-    var email = req.body.email,
-        password = req.body.password;
+    const email = req.body.email;
+    const password = req.body.password;
 
     // find user and generate access token
     User.authenticate(email, password, function (err, user) {
-        if (err) return next(err);
+        if (err) {
+            return next(err);
+        }
         user.generateSaveAccessToken(function (err, accessToken) {
             // handle errors
-            if (err) return next(err);
+            if (err) {
+                return next(err);
+            }
 
             // return successful response with access token
             res.status(201);
@@ -27,3 +34,13 @@ app.post("/token", function (req, res, next) {
         });
     });
 });
+
+app.get("/facebook", passport.authenticate("facebook"));
+
+app.get("/facebook/callback",
+    passport.authenticate("facebook", { failureRedirect: "/auth/facebook" }),
+    (req, res) => {
+        const user = JSON.stringify(req.user);
+        res.redirect(`OAuthLogin://login?user=${user}`);
+    });
+

--- a/lib/controllers/auth.js
+++ b/lib/controllers/auth.js
@@ -6,6 +6,7 @@ const passport = require("passport");
 const jwt = require("jsonwebtoken");
 const _ = require("lodash");
 const config = require("../../config");
+const errors = require("../errors");
 
 const app = module.exports = express();
 
@@ -66,6 +67,16 @@ app.get("/facebook/token", passport.authenticate("facebook"), (req, res, next) =
         });
         return;
     }
-    res.status(200);
-    res.json({ token });
+    User.findOne({ email }, function(err, user) {
+        if (err) {
+            return next(err);
+        }
+
+        console.log(errors.ERRORS.USER_NOT_REGISTERED);
+        if (!user) {
+            return next(errors.ERRORS.USER_NOT_REGISTERED);
+        }
+        res.status(200);
+        res.json({ token });
+    });
 });

--- a/lib/controllers/auth.js
+++ b/lib/controllers/auth.js
@@ -4,6 +4,7 @@ const express = require("express");
 const mongoose = require("mongoose");
 const passport = require("passport");
 const jwt = require("jsonwebtoken");
+const _ = require("lodash");
 const config = require("../../config");
 
 const app = module.exports = express();
@@ -44,9 +45,27 @@ app.get("/facebook/callback", (req, res) => {
     res.redirect(`OAuthLogin://authorize?code=${code}`);
 });
 
-app.get("/facebook/token", passport.authenticate("facebook"), (req, res) => {
+app.get("/facebook/token", passport.authenticate("facebook"), (req, res, next) => {
     const { id, lastName, firstName } = req.user;
-    const userInfo = { id, idType: "facebook" };
+    const email = `${id}@facebook.com`;
+    const userInfo = { id, idType: "facebook", email };
     const token = jwt.sign(userInfo, config.jwtSecret, { expiresIn: config.jwtExpiresIn || 3600 });
-    res.json({ token, lastName, firstName });
+    const register = _.get(req, "query.register", "false") === "true";
+    if (register) {
+        User.create({
+            email,
+            password: "PASSw0rd",
+            firstName,
+            lastName
+        }, function (err) {
+            if (err) {
+                return next(err);
+            }
+            res.status(200);
+            res.json({ token });
+        });
+        return;
+    }
+    res.status(200);
+    res.json({ token });
 });

--- a/lib/controllers/auth.js
+++ b/lib/controllers/auth.js
@@ -3,6 +3,8 @@
 const express = require("express");
 const mongoose = require("mongoose");
 const passport = require("passport");
+const jwt = require("jsonwebtoken");
+const config = require("../../config");
 
 const app = module.exports = express();
 
@@ -37,10 +39,14 @@ app.post("/token", function (req, res, next) {
 
 app.get("/facebook", passport.authenticate("facebook"));
 
-app.get("/facebook/callback",
-    passport.authenticate("facebook", { failureRedirect: "/auth/facebook" }),
-    (req, res) => {
-        const user = JSON.stringify(req.user);
-        res.redirect(`OAuthLogin://login?user=${user}`);
-    });
+app.get("/facebook/callback", (req, res) => {
+    const code = req.query.code;
+    res.redirect(`OAuthLogin://authorize?code=${code}`);
+});
 
+app.get("/facebook/token", passport.authenticate("facebook"), (req, res) => {
+    const { id, lastName, firstName } = req.user;
+    const userInfo = { id, idType: "facebook" };
+    const token = jwt.sign(userInfo, config.jwtSecret, { expiresIn: config.jwtExpiresIn || 3600 });
+    res.json({ token, lastName, firstName });
+});

--- a/lib/controllers/auth.js
+++ b/lib/controllers/auth.js
@@ -71,8 +71,6 @@ app.get("/facebook/token", passport.authenticate("facebook", { session: false })
         if (err) {
             return next(err);
         }
-
-        console.log(errors.ERRORS.USER_NOT_REGISTERED);
         if (!user) {
             return next(errors.ERRORS.USER_NOT_REGISTERED);
         }

--- a/lib/controllers/helpers/auth.js
+++ b/lib/controllers/helpers/auth.js
@@ -3,12 +3,42 @@
 var mongoose        = require("mongoose"),
     errors          = require("../../errors.js").ERRORS;
 
+var User = mongoose.model("User");
+
 var passportAuth    = require("./passport")();
 // Authentication middlewares
 
 // Ensures a user is logged in and saves their User object into req.user
 // Should be called in all non-user-registration API requests
-module.exports.authenticate = passportAuth.authenticate;
+if (process.env.NODE_ENV === "test") {
+  module.exports.authenticate = function authenticate(req, res, next) {
+      var auth = req.headers.authorization;
+
+      // don't authenticate OPTIONS requests for browser compatbility
+      if (req.method === "OPTIONS") return next();
+
+      // must be of the form "Bearer xxx" where xxx is a (variable-length)
+      // access token
+      if (typeof auth === "undefined" || auth.indexOf("Bearer") !== 0) {
+          return next(errors.ACCESS_TOKEN_REQUIRED);
+      }
+
+      // Remove "Bearer " from start of auth
+      var accessToken = auth.slice(7);
+
+      // find user and store in request
+      User.authenticateFromAccessToken(accessToken, function (err, user) {
+          if (err) return next(err);
+
+          req.user = user;
+          // proceed to handle request as normal
+          next();
+      });
+  };
+
+} else {
+  module.exports.authenticate = passportAuth.authenticate;
+}
 
 // find patient from patient ID, and ensure they have the access level
 // specified. note: this should **not** be used to authorize users for resources

--- a/lib/controllers/helpers/auth.js
+++ b/lib/controllers/helpers/auth.js
@@ -3,42 +3,12 @@
 var mongoose        = require("mongoose"),
     errors          = require("../../errors.js").ERRORS;
 
-var User = mongoose.model("User");
-
 var passportAuth    = require("./passport")();
 // Authentication middlewares
 
 // Ensures a user is logged in and saves their User object into req.user
 // Should be called in all non-user-registration API requests
-if (process.env.NODE_ENV === "test") {
-  module.exports.authenticate = function authenticate(req, res, next) {
-      var auth = req.headers.authorization;
-
-      // don't authenticate OPTIONS requests for browser compatbility
-      if (req.method === "OPTIONS") return next();
-
-      // must be of the form "Bearer xxx" where xxx is a (variable-length)
-      // access token
-      if (typeof auth === "undefined" || auth.indexOf("Bearer") !== 0) {
-          return next(errors.ACCESS_TOKEN_REQUIRED);
-      }
-
-      // Remove "Bearer " from start of auth
-      var accessToken = auth.slice(7);
-
-      // find user and store in request
-      User.authenticateFromAccessToken(accessToken, function (err, user) {
-          if (err) return next(err);
-
-          req.user = user;
-          // proceed to handle request as normal
-          next();
-      });
-  };
-
-} else {
-  module.exports.authenticate = passportAuth.authenticate;
-}
+module.exports.authenticate = passportAuth.authenticate;
 
 // find patient from patient ID, and ensure they have the access level
 // specified. note: this should **not** be used to authorize users for resources

--- a/lib/controllers/helpers/passport.js
+++ b/lib/controllers/helpers/passport.js
@@ -12,7 +12,7 @@ const errors = require("../../errors.js").ERRORS;
 const jwtOptions = {
   jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
   secretOrKey: config.jwtSecret,
-  passRqToCallback: true
+  passReqToCallback: true
 };
 
 const noop = (req, res, next) => next();
@@ -27,14 +27,6 @@ const strategies = {
         passport.use(new FacebookStrategy(config.facebook, function (accessToken, refreshToken, profile, done) {
             done(null, transformFacebookProfile(profile._json));
         }));
-        // Serialize user into the sessions
-        passport.serializeUser((user, done) => {
-            return done(null, user);
-        });
-        // Deserialize user from the sessions
-        passport.deserializeUser((user, done) => {
-            return done(null, user);
-        });
     },
     amida() {
         const jwtLogin = new JwtStrategy(jwtOptions, function(req, payload, done) {
@@ -105,9 +97,6 @@ module.exports = function() {
 
     return {
         initialize: initializations[authType],
-        authenticate: authentications[authType],
-        useSession() {
-            return authType === "facebook";
-        }
+        authenticate: authentications[authType]
     };
 };

--- a/lib/controllers/helpers/passport.js
+++ b/lib/controllers/helpers/passport.js
@@ -7,7 +7,6 @@ const ExtractJwt = require("passport-jwt").ExtractJwt;
 const FacebookStrategy = require("passport-facebook");
 
 const User = require("../../models/user/user");
-const errors = require("../../errors.js").ERRORS;
 
 const jwtOptions = {
   jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -15,88 +14,33 @@ const jwtOptions = {
   passReqToCallback: true
 };
 
-const noop = (req, res, next) => next();
-
 const transformFacebookProfile = (profile) => {
     const { id, last_name: lastName, first_name: firstName } = profile;
     return { id, lastName, firstName };
 };
 
-const strategies = {
-    facebook() {
-        passport.use(new FacebookStrategy(config.facebook, function (accessToken, refreshToken, profile, done) {
-            done(null, transformFacebookProfile(profile._json));
-        }));
-    },
-    amida() {
-        const jwtLogin = new JwtStrategy(jwtOptions, function(req, payload, done) {
-            User.findOne({ email: payload.email }, function(err, user) {
-                if (err) {
-                    return done(err, false);
-                }
-                if (user) {
-                    req.user = user;
-                    return done(null, user);
-                }
-                return done(null, false);
-            });
-        });
-        passport.use(jwtLogin);
-    },
-    local() {}
-};
-
-const initializations = {
-    facebook() {
-        return passport.initialize();
-    },
-    amida() {
-        return passport.initialize();
-    },
-    local() {
-        return noop;
-    }
-};
-
-const authentications = {
-    facebook: passport.authenticate(),
-    amida: passport.authenticate("jwt", { session: false }),
-    local: function authenticate(req, res, next) {
-        var auth = req.headers.authorization;
-
-        // don"t authenticate OPTIONS requests for browser compatbility
-        if (req.method === "OPTIONS") return next();
-
-        // must be of the form "Bearer xxx" where xxx is a (variable-length)
-        // access token
-        if (typeof auth === "undefined" || auth.indexOf("Bearer") !== 0) {
-            return next(errors.ACCESS_TOKEN_REQUIRED);
-        }
-
-        // Remove "Bearer " from start of auth
-        var accessToken = auth.slice(7);
-
-        // find user and store in request
-         User.authenticateFromAccessToken(accessToken, function (err, user) {
-            if (err) return next(err);
-
-            req.user = user;
-            // proceed to handle request as normal
-            next();
-        });
-    }
-};
-
 module.exports = function() {
-    const authType = process.env.NODE_ENV === "test" ? "local" : config.authType || "amida";
-    const strategy = strategies[authType];
-    if (!strategy) {
-        throw new Error(`Unknown auth type "${authType}"`);
-    }
-    strategy();
+    const jwtLogin = new JwtStrategy(jwtOptions, function(req, payload, done) {
+      User.findOne({ email: payload.email }, function(err, user) {
+        if (err) { return done(err, false); }
+
+        if (user) {
+          req.user = user;
+          done(null, user);
+        } else {
+          done(null, false);
+        }
+      });
+    });
+    passport.use(jwtLogin);
+    passport.use(new FacebookStrategy(config.facebook, function (accessToken, refreshToken, profile, done) {
+        done(null, transformFacebookProfile(profile._json));
+    }));
 
     return {
-        initialize: initializations[authType],
-        authenticate: authentications[authType]
-    };
+        initialize: function() {
+            return passport.initialize();
+        },
+        authenticate: passport.authenticate("jwt", { session: false })
+      };
 };

--- a/lib/controllers/helpers/passport.js
+++ b/lib/controllers/helpers/passport.js
@@ -1,35 +1,119 @@
 "use strict";
+
 const passport = require("passport");
 const config = require("../../../config");
 const JwtStrategy = require("passport-jwt").Strategy;
 const ExtractJwt = require("passport-jwt").ExtractJwt;
+const FacebookStrategy = require("passport-facebook");
 
 const User = require("../../models/user/user");
+const errors = require("../../errors.js").ERRORS;
 
 const jwtOptions = {
   jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
   secretOrKey: config.jwtSecret,
-  passReqToCallback: true
+  passRqToCallback: true
+};
+
+const noop = (req, res, next) => next();
+
+const transformFacebookProfile = (profile, accessToken) => {
+    console.log("***********");
+    console.log(profile);
+    console.log("***********");
+    return {
+        name: profile.name,
+        avatar: profile.picture.data.url,
+        accessToken
+    };
+};
+
+const strategies = {
+    facebook() {
+        passport.use(new FacebookStrategy(config.facebook, function (accessToken, refreshToken, profile, done) {
+            done(null, transformFacebookProfile(profile._json, accessToken));
+        }));
+        // Serialize user into the sessions
+        passport.serializeUser((user, done) => {
+            return done(null, user);
+        });
+        // Deserialize user from the sessions
+        passport.deserializeUser((user, done) => {
+            return done(null, user);
+        });
+    },
+    amida() {
+        const jwtLogin = new JwtStrategy(jwtOptions, function(req, payload, done) {
+            User.findOne({ email: payload.email }, function(err, user) {
+                if (err) {
+                    return done(err, false);
+                }
+                if (user) {
+                    req.user = user;
+                    return done(null, user);
+                }
+                return done(null, false);
+            });
+        });
+        passport.use(jwtLogin);
+    },
+    local() {}
+};
+
+const initializations = {
+    facebook() {
+        return passport.initialize();
+    },
+    amida() {
+        return passport.initialize();
+    },
+    local() {
+        return noop;
+    }
+};
+
+const authentications = {
+    facebook: passport.authenticate(),
+    amida: passport.authenticate("jwt", { session: false }),
+    local: function authenticate(req, res, next) {
+        var auth = req.headers.authorization;
+
+        // don"t authenticate OPTIONS requests for browser compatbility
+        if (req.method === "OPTIONS") return next();
+
+        // must be of the form "Bearer xxx" where xxx is a (variable-length)
+        // access token
+        if (typeof auth === "undefined" || auth.indexOf("Bearer") !== 0) {
+            return next(errors.ACCESS_TOKEN_REQUIRED);
+        }
+
+        // Remove "Bearer " from start of auth
+        var accessToken = auth.slice(7);
+
+        // find user and store in request
+         User.authenticateFromAccessToken(accessToken, function (err, user) {
+            if (err) return next(err);
+
+            req.user = user;
+            // proceed to handle request as normal
+            next();
+        });
+    }
 };
 
 module.exports = function() {
-    const jwtLogin = new JwtStrategy(jwtOptions, function(req, payload, done) {
-      User.findOne({ email: payload.email }, function(err, user) {
-        if (err) { return done(err, false); }
+    const authType = process.env.NODE_ENV === "test" ? "local" : config.authType || "amida";
+    const strategy = strategies[authType];
+    if (!strategy) {
+        throw new Error(`Unknown auth type "${authType}"`);
+    }
+    strategy();
 
-        if (user) {
-          req.user = user;
-          done(null, user);
-        } else {
-          done(null, false);
-        }
-      });
-    });
-    passport.use(jwtLogin);
     return {
-        initialize: function() {
-            return passport.initialize();
-        },
-        authenticate: passport.authenticate("jwt", { session: false })
-      };
+        initialize: initializations[authType],
+        authenticate: authentications[authType],
+        useSession() {
+            return authType === "facebook";
+        }
+    };
 };

--- a/lib/controllers/helpers/passport.js
+++ b/lib/controllers/helpers/passport.js
@@ -17,21 +17,15 @@ const jwtOptions = {
 
 const noop = (req, res, next) => next();
 
-const transformFacebookProfile = (profile, accessToken) => {
-    console.log("***********");
-    console.log(profile);
-    console.log("***********");
-    return {
-        name: profile.name,
-        avatar: profile.picture.data.url,
-        accessToken
-    };
+const transformFacebookProfile = (profile) => {
+    const { id, last_name: lastName, first_name: firstName } = profile;
+    return { id, lastName, firstName };
 };
 
 const strategies = {
     facebook() {
         passport.use(new FacebookStrategy(config.facebook, function (accessToken, refreshToken, profile, done) {
-            done(null, transformFacebookProfile(profile._json, accessToken));
+            done(null, transformFacebookProfile(profile._json));
         }));
         // Serialize user into the sessions
         passport.serializeUser((user, done) => {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -59,6 +59,7 @@ module.exports = {
         PASSWORD_REQUIRED: new APIError("password_required", 400),
         INVALID_EMAIL: new APIError("invalid_email", 400),
         USER_ALREADY_EXISTS: new APIError("user_already_exists", 400),
+        USER_NOT_REGISTERED: new APIError("not_registered", 400),
 
         // Authentication
         USER_NOT_FOUND: new APIError("wrong_email_password", 401),

--- a/package-lock.json
+++ b/package-lock.json
@@ -6702,12 +6702,27 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsonwebtoken": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.4.1.tgz",
-      "integrity": "sha1-IFXGORlf/lYxT6alHfAkaBhqlpU=",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.1.1.tgz",
+      "integrity": "sha512-+ijVOtfLMlCII8LJkvabaKX3+8tGrGjiCTfzoed2D1b/ebKTO1hIYBQUJHbd9dJ9Fa4kH+dhYEd1qDwyzDLUUw==",
       "requires": {
         "jws": "3.1.4",
-        "ms": "0.7.1"
+        "lodash.includes": "4.3.0",
+        "lodash.isboolean": "3.0.3",
+        "lodash.isinteger": "4.0.4",
+        "lodash.isnumber": "3.0.3",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
+        "lodash.once": "4.1.1",
+        "ms": "2.1.1",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
       }
     },
     "jsprim": {
@@ -7262,6 +7277,11 @@
       "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
       "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -7271,6 +7291,31 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.keys": {
       "version": "3.1.2",
@@ -10541,6 +10586,15 @@
             "commander": "2.9.0",
             "is-my-json-valid": "2.16.0",
             "pinkie-promise": "2.0.1"
+          }
+        },
+        "jsonwebtoken": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.4.1.tgz",
+          "integrity": "sha1-IFXGORlf/lYxT6alHfAkaBhqlpU=",
+          "requires": {
+            "jws": "3.1.4",
+            "ms": "0.7.1"
           }
         },
         "lodash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5347,6 +5347,12 @@
             "type-check": "0.3.2"
           }
         },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        },
         "minimatch": {
           "version": "2.0.10",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
@@ -7209,9 +7215,9 @@
       }
     },
     "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -9341,6 +9347,13 @@
         "mime": "1.3.4",
         "request": "2.81.0",
         "smtpapi": "1.3.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        }
       }
     },
     "sequencify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8129,6 +8129,12 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE=",
+      "dev": true
+    },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
@@ -8500,6 +8506,15 @@
         "pause": "0.0.1"
       }
     },
+    "passport-facebook": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/passport-facebook/-/passport-facebook-2.1.1.tgz",
+      "integrity": "sha1-w50LUq5NWRYyRaTiGnubYyEwMxE=",
+      "dev": true,
+      "requires": {
+        "passport-oauth2": "1.4.0"
+      }
+    },
     "passport-jwt": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-3.0.0.tgz",
@@ -8526,6 +8541,18 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
+      }
+    },
+    "passport-oauth2": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.4.0.tgz",
+      "integrity": "sha1-9i+BWDy+EmCb585vFguTlaJ7hq0=",
+      "dev": true,
+      "requires": {
+        "oauth": "0.9.15",
+        "passport-strategy": "1.0.0",
+        "uid2": "0.0.3",
+        "utils-merge": "1.0.1"
       }
     },
     "passport-strategy": {
@@ -10701,6 +10728,12 @@
       "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
       "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
     },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
+      "dev": true
+    },
     "ultron": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
@@ -10975,6 +11008,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
+      "dev": true
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
     "uuid": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "image-type": "^2.0.2",
     "inflected": "^1.1.6",
     "jsonwebtoken": "^8.1.1",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.5",
     "moment": "^2.10.3",
     "moment-timezone": "^0.4.0",
     "mongodb": "~2.1.21",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "mocha": "^2.2.5",
     "mocha-shared": "^0.2.0",
     "monky": "^0.6.7",
+    "passport-facebook": "^2.1.1",
     "q": "^1.4.1",
     "sinon": "^1.14.1"
   },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "handlebars": "^3.0.3",
     "image-type": "^2.0.2",
     "inflected": "^1.1.6",
+    "jsonwebtoken": "^8.1.1",
     "lodash": "^3.10.1",
     "moment": "^2.10.3",
     "moment-timezone": "^0.4.0",


### PR DESCRIPTION
This is the server side of external registration. Currently only for facebook.

1) You need to register the app with Facebook at https://developers.facebook.com. You can follow the instructions in https://rationalappdev.com/logging-into-react-native-apps-with-facebook-or-google/
2) Example config.facebook is added config.js.example. Those setting should match to the App you created.
3) Otherwise this implements necessary end points for Facebook oauth. The  implementation creates a jwt at the end of the Facebook auth so that authorization for other end points remain the same.

Should be tested together with orange-ignite PR.