### PR TITLE
Hotfix: CORS make * enable all domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ All requests made to this API must have HTTP header `x-client-secret` with a val
 - When using Postman, Postman sets the origin to `chrome-extension://fhbjgbiflinjbdggehcddcbncdddomop`, or something like that (see following sentence for clarity), so you must the this variable to this value. If this exact value does not work, the `orange-api` prints an error message to stdout saying that CORS failed and specifying what the origin should be set to.
 - To set multiple domains, place in quotes and separate the domains with commas like this: `"http://domain1.com, https://domain2.com"`
 - Don't forget that if your client is running on a port other than 80 or 443, you will have to specify this as well, as in `http://localhost:12345`.
+- To enable all domains (which is insecure and therefore should only be done in development), set to `*` or `'something.com, doesntmatter.com, *'`
 
 ##### `MONGO_URI` (Required)
 
@@ -277,7 +278,7 @@ The Apple Developer Console name of this app.
 
 Note: Unlike iOS push notifications, Android push notifications do work in development.
 
-`PUSH_NOTIFICATIONS_FCM_API_URL` Url of Google Android Firebase service.
+`PUSH_NOTIFICATIONS_FCM_API_URL` URL of Google Android Firebase service.
 
 `PUSH_NOTIFICATIONS_FCM_SERVER_KEY` Identifies to Google that a server belonging to Amida is making this push notification request.
 - Value stored in Amida's password vault.

--- a/app.js
+++ b/app.js
@@ -72,7 +72,7 @@ app.use(cors({
     // TODO: Figure out why origin is coming through as undefined, which seems to be
     // happening because this is running inside a docker container, fix the problem,
     // and remove the `origin === undefined` clause.
-    if (corsDomains.indexOf(origin) !== -1 || origin === undefined) {
+    if (corsDomains.indexOf(origin) !== -1 || corsDomains.indexOf("*") !== -1 || config.accessControlAllowOrigin === "*" || origin === undefined) {
       // Cors passes!
       callback(null, true);
     } else {


### PR DESCRIPTION
## What it does:

With these changes, if you set `ACCESS_CONTROL_ALLOW_ORIGIN=*` OR `='http://some-list-of-domains.com, https://anything.really, *'`, CORS should always pass.

## To test

CORS doesn't apply to mobile apps, so you need a web application to test. `orange-web` is recommended. You need to get your `orange-web` client to make a request to the `orange-api`. An easy way to do this is to go to the /login or any 404 page on `orange-web` and use the create new user widget, which makes a call to the `orange-api`. Doing so, CORS should behave as follows:

Note: "Passes" below means the browser console does not produce any CORS erros/warnings, and the request you made works.

- `ACCESS_CONTROL_ALLOW_ORIGIN=*` request passes CORS
- `ACCESS_CONTROL_ALLOW_ORIGIN='some-list-of-domains.com, anything.really, *'` request passes CORS
- `ACCESS_CONTROL_ALLOW_ORIGIN='http://the-domain-where-your-web-client-is-running:1776.com'` request passes CORS.
- `ACCESS_CONTROL_ALLOW_ORIGIN='http://not-your-domain.com'` request fails CORS (meaning the console in your web browser produces a CORS error/warning).



