### PR TITLE
including role in response to get all users

### DIFF
--- a/lib/controllers/users.js
+++ b/lib/controllers/users.js
@@ -305,7 +305,7 @@ users.get("/", authenticate, function (req, res) {
 });
 
 // Fields we want to output in JSON response (in addition to ID)
-var formatList = crud.formatListGenerator(["first_name", "last_name", "email"], "users");
+var formatList = crud.formatListGenerator(["first_name", "last_name", "email", "role"], "users");
 var returnListData = crud.returnListData;
 // Get list of users
 var paramParser = list.parseListParameters(["id", "first_name", "last_name"],


### PR DESCRIPTION
# What does this do?
This includes the role in the response to the get all users endpoint. This is helpful for orange-web to separate the clinicians into one form select component and the patients into another.

# How do I test this?
GET /user/all as a programAdministrator and ensure that the role of each user is included in the response