### PR TITLE
Add /notes /moods /side-effects paths to /journal

### DIFF
--- a/lib/controllers/journal.js
+++ b/lib/controllers/journal.js
@@ -1,11 +1,14 @@
 "use strict";
+
 var express         = require("express"),
     async           = require("async"),
+    mongoose        = require("mongoose"),
     crud            = require("./helpers/crud.js"),
     list            = require("./helpers/list.js"),
     errors          = require("../errors.js").ERRORS,
     medications     = require("./medications.js"),
-    auth            = require("./helpers/auth.js");
+    auth            = require("./helpers/auth.js"),
+    winstonInstance = require("../../config/winston.js");
 
 var journal = module.exports = express.Router({ mergeParams: true });
 
@@ -100,6 +103,45 @@ function setRole(req, res, next) {
     return next();
 }
 
+function notesMoodsSideEffects (req, res, next) {
+  var q = mongoose.model("Patient").findById(req.patient._id);
+
+  console.log("this is frustrating");
+  q.exec(function (err, patient) {
+    if (err) {
+      return next(errors.FETCHING_JOURNAL_ENTRIES_FAILED);
+    }
+
+    var results = [];
+    if (req.route.path === "/notes") {
+      results = patient.entries.filter(function (entry) {
+        return !!entry.text;
+      });
+    }
+    else if (req.route.path === "/side-effects") {
+      results = patient.entries.filter(function (entry) {
+        return !!entry.sideEffect;
+      });
+    }
+    else if (req.route.path === "/moods") {
+      results = patient.entries.filter(function (entry) {
+        return !!entry.mood;
+      });
+    }
+
+    winstonInstance.debug({message: `journal.get(${req.route.path})`, results: results});
+
+    res.status(200).send({
+      count: results.length,
+      success: true,
+      entries: results
+    });
+  });
+}
+
+journal.get("/notes", auth.authorize("read"), notesMoodsSideEffects);
+journal.get("/moods", auth.authorize("read"), notesMoodsSideEffects);
+journal.get("/side-effects", auth.authorize("read"), notesMoodsSideEffects);
 
 // Create a new journal entry for the specified patient (requires write access)
 journal.post("/",

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -123,6 +123,7 @@ module.exports = {
         INVALID_SIDEEFFECT: new APIError("invalid_sideeffect", 400),
         INVALID_MOOD: new APIError("invalid_mood", 400),
         INVALID_ACTIVITY: new APIError("invalid_activity", 400),
+        FETCHING_JOURNAL_ENTRIES_FAILED: new APIError("fetching_journal_entries_failed", 500, "Fetching journal entries failed."),
 
         // Habits
         INVALID_WAKE: new APIError("invalid_wake", 400),


### PR DESCRIPTION
To test, for a patient that has some notes, moods, and side effects in their record, do GET requests against:

`/v1/patient/:patientId/journal/notes`
`/v1/patient/:patientId/journal/moods`
`/v1/patient/:patientId/journal/side-effects`

Each should return an object with
```js
{
  success: true
  count: THE_COUNT,
  entries: [ /* an array of journal items with members that are either text data, mood data, or side effect data */ ]
}
```