### PR TITLE
Feature/orange 885 va formulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ API for Orange medication management app. RESTful and implemented in Node & Mong
     - Database Address
 - `npm install`
 
+### Enabling VA Formulary Search
+orange-api has an endpoint for searching for medications in the VA Formulary. This is enabled by populating a collection in MongoDB with the contents of the VA Formulary.
+
+The latest spreadsheet that contains the VA Formulary can be downloaded from [here](https://www.pbm.va.gov/NationalFormulary.asp).
+
+Import the data from the spreadsheet into MongoDB with the npm script `import_va_formulary`. For example, `npm run import_va_formulary ~/Downloads/VANF-October_2018.xls`.
+
 ## Enabling Push Notifications
 
 Note: This is optional. These steps are in their own section because this setup is complicated and not required if you don't need to develop/test push notifications.

--- a/app.js
+++ b/app.js
@@ -35,6 +35,7 @@ app.use(expressWinston.logger({
 // in patient.js, so don't require them again here
 require("./lib/models/counter.js"); // Require first
 require("./lib/models/rxnorm.js");
+require("./lib/models/formulary_entry.js");
 // Patient and User require a getter function for a gridfs client (set as an express
 // setting in run.js but may not be immediately accessible hence the getter function)
 function getGfs() {
@@ -130,6 +131,8 @@ router.use("/user", require("./lib/controllers/users.js"));
 // External APIs
 router.use("/npi", require("./lib/controllers/npi.js"));
 router.use("/rxnorm", require("./lib/controllers/rxnorm.js"));
+
+router.use("/formulary", require("./lib/controllers/formulary_entries.js"));
 
 // User sharing
 router.use("/", require("./lib/controllers/requests.js"));

--- a/import_va_formulary.js
+++ b/import_va_formulary.js
@@ -1,0 +1,83 @@
+'use strict'
+
+const xlsx = require('xlsx');
+const csvtojson = require('csvtojson');
+
+const keypress = async () => {
+  console.log('\tPress any key to continue or Control-C to cancel.\n');
+  process.stdin.setRawMode(true);
+  return new Promise(resolve => process.stdin.once('data', data => {
+    const byteArray = [...data];
+    if (byteArray.length > 0 && byteArray[0] === 3) {
+      console.log('^C');
+      process.exit(1);
+    }
+    process.stdin.setRawMode(false);
+    resolve();
+  }))
+};
+
+(async () => {
+  const spreadsheetFileName = process.argv.pop();
+
+  console.info(`Using spreadsheet '${spreadsheetFileName}'`);
+  await keypress();
+
+  let spreadsheet
+  try {
+    spreadsheet = xlsx.readFile(spreadsheetFileName);
+  } catch (e) {
+    console.error(`Could not parse '${spreadsheetFileName}' as a xlsx spreadsheet`);
+    return 1;
+  }
+  let formularySheet = spreadsheet.Sheets['Formulary'];
+  if (!formularySheet) {
+    console.warn('Could not find sheet named \'Formulary\'; using first sheet instead.');
+    await keypress();
+    formularySheet = spreadsheet.Sheets[spreadsheet.SheetNames[0]]
+  }
+
+  // One big string with everything in it, csv format
+  const csvString = xlsx.utils.sheet_to_csv(formularySheet);
+  // Parsed into 2D array
+  const rows = await csvtojson({ noheader: true, output: 'csv' }).fromString(csvString)
+  // Index of the row that starts with 'VA Class', this should be the header row of the actual data
+  const indexOfHeaderRow = rows.map((row) => row[0]).indexOf('VA Class');
+  console.info('Found the header of the data at row', indexOfHeaderRow);
+  await keypress();
+
+  const rowsWithoutMeta = rows.slice(indexOfHeaderRow);
+  // Now that we sliced off the extra info at the top of the sheet,
+  // we glue this back into one big string so we can parse it again with headers enabled
+  const csvStringWithoutMeta = rowsWithoutMeta.map((row) => row.map((value) => `"${value}"`).join(',')).join('\n');
+
+  // Array of objects, keys for each value are derived from the header
+  const parsedFormulary = await csvtojson().fromString(csvStringWithoutMeta)
+
+  const cleanedFormulary = parsedFormulary.map((entry) => ({
+    vaClass: entry['VA Class'],
+    restriction: entry['Restriction'],
+    genericName: entry['Generic'],
+    dosageForm: entry['Dosage Form'],
+    comments: entry['Comments'],
+  }));
+
+  // Currently, dosageForm is a list of forms.
+  // Now we split this up so that we have individual entries for each dosage form.
+  const expandedFormularyByDosageForm = cleanedFormulary.reduce((expandedFormularyByDosageForm, entry) => {
+    const dosageForms = entry.dosageForm.split(',');
+    const expandedEntries = dosageForms.map((form) => ({ ...entry, dosageForm: form }));
+    return expandedFormularyByDosageForm.concat(expandedEntries);
+  }, []);
+
+  console.info(`About to *replace* the formulary collection contents with these ${expandedFormularyByDosageForm.length} entries.`);
+  await keypress();
+
+  console.error('jk, unimplemented');
+
+})()
+.then(process.exit)
+.catch((err) => {
+  console.error(err);
+  process.exit(-1);
+});

--- a/lib/controllers/formulary_entries.js
+++ b/lib/controllers/formulary_entries.js
@@ -1,0 +1,30 @@
+"use strict";
+var express         = require("express"),
+    mongoose        = require("mongoose"),
+    crud            = require("./helpers/crud.js"),
+    list            = require("./helpers/list.js");
+
+var FormularyEntry = mongoose.model("FormularyEntry");
+var formularyEntries = module.exports = express.Router({ mergeParams: true });
+
+// Fields we want to output in JSON response (in addition to ID)
+var formatList = crud.formatListGenerator(
+  ["vaClass", "genericName", "dosageForm", "restriction", "comments"],
+  "formularyEntries"
+);
+var returnListData = crud.returnListData;
+// Search formulary
+var paramParser = list.parseListParameters(["id"], ["vaClass", "genericName"]);
+formularyEntries.get("/search", paramParser, function (req, res, next) {
+    var params = {
+        limit: req.listParameters.limit,
+        offset: req.listParameters.offset,
+        sortBy: req.listParameters.sortBy,
+        sortOrder: req.listParameters.sortOrder,
+        vaClass: req.listParameters.filters.vaClass,
+        genericName: req.listParameters.filters.genericName
+    };
+
+    // the model handles the querying for us
+    return FormularyEntry.findByParameters({}, params, returnListData(res, next));
+}, formatList);

--- a/lib/models/formulary_entry.js
+++ b/lib/models/formulary_entry.js
@@ -1,0 +1,64 @@
+"use strict";
+var mongoose = require("mongoose");
+var async = require("async");
+var regexEscape = require("./helpers/regex_escape.js").regexEscape;
+
+var FormularyEntrySchema = new mongoose.Schema({
+    vaClass: { type: String, required: true },
+    genericName: { type: String, required: true },
+    dosageForm: { type: String, default: "" },
+    restriction: { type: String, default: "" },
+    comments: { type: String, default: "" }
+});
+
+FormularyEntrySchema.statics.findByParameters = function (query, parameters, done) {
+    // build up the mongo query to execute
+    // perform fuzzy matching by comparing double metaphone (better soundex) values
+    var vaClass = parameters.vaClass, genericName = parameters.genericName;
+    if (typeof genericName !== "undefined" && genericName !== null && genericName.length !== 0) {
+        query.genericName = new RegExp(regexEscape(genericName), "i");
+    }
+    if (typeof vaClass !== "undefined" && vaClass !== null && vaClass.length !== 0) {
+        query.vaClass = vaClass;
+    }
+
+    // find users
+    var find = function (callback) {
+        // basic query
+        var q = this.find(query);
+
+        if (typeof parameters.sortBy === "undefined") {
+            parameters.sortBy = "id";
+        }
+        if (typeof parameters.sortOrder === "undefined") {
+            parameters.sortOrder = "asc";
+        }
+        // if we should sort users, do so
+        if (typeof parameters.sortBy !== "undefined" && typeof parameters.sortOrder !== "undefined") {
+            // sort patients by the specified field in the specified order
+            var sort = {};
+            if (parameters.sortBy === "id") parameters.sortBy = "_id";
+            sort[parameters.sortBy] = parameters.sortOrder;
+
+            q = q.sort(sort);
+        }
+
+        // if we should paginate, do so
+        if (typeof parameters.offset !== "undefined") q = q.skip(parameters.offset);
+        if (typeof parameters.limit !== "undefined") q = q.limit(parameters.limit);
+
+        q.exec(callback);
+    }.bind(this);
+
+    // count patients
+    var count = function (callback) {
+        this.countDocuments(query, callback);
+    }.bind(this);
+
+    return async.parallel({ data: find, count: count }, function (err, results) {
+        if (err) return done(err);
+        done(results.find, results.data, results.count);
+    });
+};
+
+module.exports = mongoose.model("FormularyEntry", FormularyEntrySchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,16 @@
         }
       }
     },
+    "adler-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.2.0.tgz",
+      "integrity": "sha1-aj5r8KY5ALoVZSgIyxXGgT0aXyU=",
+      "dev": true,
+      "requires": {
+        "exit-on-epipe": "1.0.1",
+        "printj": "1.1.2"
+      }
+    },
     "after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
@@ -1008,6 +1018,18 @@
         "lazy-cache": "1.0.4"
       }
     },
+    "cfb": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.1.0.tgz",
+      "integrity": "sha512-ZqfxNGWTMKhd0a/n6YKJLq8hWbd5kR3cA4kXwUj9vVEdHlwJ09werR8gN15Z7Y1FTXqdD6dE3GGCxv4uc28raA==",
+      "dev": true,
+      "requires": {
+        "adler-32": "1.2.0",
+        "commander": "2.17.1",
+        "crc-32": "1.2.0",
+        "printj": "1.1.2"
+      }
+    },
     "chai": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
@@ -1220,6 +1242,24 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "codepage": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.14.0.tgz",
+      "integrity": "sha1-jL4lSBMjVZ19MHVxsP/5HnodL5k=",
+      "dev": true,
+      "requires": {
+        "commander": "2.14.1",
+        "exit-on-epipe": "1.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.14.1",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+          "dev": true
+        }
+      }
     },
     "coffee-script": {
       "version": "1.12.7",
@@ -1454,6 +1494,16 @@
         }
       }
     },
+    "crc-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
+      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+      "dev": true,
+      "requires": {
+        "exit-on-epipe": "1.0.1",
+        "printj": "1.1.2"
+      }
+    },
     "cross-env": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
@@ -1527,6 +1577,28 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
       "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
       "dev": true
+    },
+    "csvtojson": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-2.0.8.tgz",
+      "integrity": "sha512-DC6YFtsJiA7t/Yz+KjzT6GXuKtU/5gRbbl7HJqvDVVir+dxdw2/1EgwfgJdnsvUT7lOnON5DvGftKuYWX1nMOQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "lodash": "4.17.10",
+        "strip-bom": "2.0.0"
+      },
+      "dependencies": {
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        }
+      }
     },
     "curry": {
       "version": "1.2.0",
@@ -2736,6 +2808,12 @@
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
+    "exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
+      "dev": true
+    },
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -3865,6 +3943,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -8411,6 +8495,12 @@
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
     },
+    "printj": {
+      "version": "1.1.2",
+      "resolved": "http://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
@@ -9457,6 +9547,15 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "ssf": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.10.2.tgz",
+      "integrity": "sha512-rDhAPm9WyIsY8eZEKyE8Qsotb3j/wBdvMWBUsOhJdfhKGLfQidRjiBUV0y/MkyCLiXQ38FG6LWW/VYUtqlIDZQ==",
+      "dev": true,
+      "requires": {
+        "frac": "1.1.2"
+      }
     },
     "sshpk": {
       "version": "1.14.2",
@@ -10706,6 +10805,21 @@
       "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
       "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo=",
       "dev": true
+    },
+    "xlsx": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.14.0.tgz",
+      "integrity": "sha512-1MDQ7XYRj6JqbXmgCN+ivL6Nr77NzyynM2Inekr5xfmVdsr628FK1nvy6d3T7Y40fbzCj4EMaica4i6YT5UfBA==",
+      "dev": true,
+      "requires": {
+        "adler-32": "1.2.0",
+        "cfb": "1.1.0",
+        "codepage": "1.14.0",
+        "commander": "2.17.1",
+        "crc-32": "1.2.0",
+        "exit-on-epipe": "1.0.1",
+        "ssf": "0.10.2"
+      }
     },
     "xml-escape": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git@github.com:amida-tech/orange-api.git"
   },
   "scripts": {
+    "import_va_formulary": "node import_va_formulary.js",
     "check_test_db": "cross-env NODE_ENV=test node check_test_db.js",
     "delete_db": "cross-env NODE_ENV=test node delete_db.js",
     "start": "grunt dev",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "chai": "^3.0.0",
     "chakram": "^1.0.0",
     "coveralls": "~3.0.1",
+    "csvtojson": "^2.0.8",
     "es6-plato": "^1.0.14",
     "eslint": "^3.19.0",
     "eslint-plugin-smells": "^1.0.1",
@@ -94,7 +95,8 @@
     "mocha-shared": "^0.2.0",
     "monky": "^0.6.11",
     "q": "^1.4.1",
-    "sinon": "^1.14.1"
+    "sinon": "^1.14.1",
+    "xlsx": "^0.14.0"
   },
   "engines": {
     "node": "0.10.x"

--- a/test/formulary/fixtures.js
+++ b/test/formulary/fixtures.js
@@ -1,0 +1,16 @@
+"use strict";
+
+var mongoose  = require("mongoose"),
+    Monky     = require("../common/monky.js");
+
+var monky = module.exports = new Monky(mongoose);
+
+/*eslint-disable key-spacing */
+monky.factory("FormularyEntry", {
+    vaClass:     "AB#n",
+    genericName: "MEDICATION #n",
+    dosageform:  "TAB",
+    restriction: "",
+    comments:    ""
+});
+/*eslint-enable key-spacing */

--- a/test/formulary/list_user_test.js
+++ b/test/formulary/list_user_test.js
@@ -1,0 +1,364 @@
+"use strict";
+var chakram         = require("chakram"),
+    mongoose        = require("mongoose"),
+    util            = require("util"),
+    Q               = require("q"),
+    querystring     = require("querystring"),
+    auth            = require("../common/auth.js"),
+    fixtures        = require("./fixtures.js");
+
+var FormularyEntry = mongoose.model("FormularyEntry");
+
+var expect = chakram.expect;
+
+describe("FormularyEntry", function () {
+    describe("Search formulary (GET /formulary/search)", function () {
+        // basic endpoint
+        var list = function (parameters) {
+            if (typeof parameters === "undefined" || parameters === null) parameters = {};
+            var query = querystring.stringify(parameters);
+
+            var url = util.format("http://localhost:5000/v1/formulary/search?%s", query);
+            return chakram.get(url, auth.genAuthHeaders());
+        };
+
+        describe("with formulary entries set up", function () {
+            // setup 40 entries
+            before(function () {
+                // generate promise to create each entry
+                var promises = [];
+                var create = function (data) {
+                    return fixtures.create("FormularyEntry", data);
+                };
+
+                // create 1 user with a custom name
+                promises.push(function () {
+                    return create({
+                        genericName: "test substring matching",
+                        vaClass: "YZ999"
+                    });
+                });
+                // create 39 entries with default data, to give a total of 40
+                // (includes the initial custom one created)
+                for (var i = 0; i < 39; i++) {
+                    /*eslint-disable no-loop-func */
+                    promises.push(function () {
+                        return create();
+                    });
+                    /*eslint-enable no-loop-func */
+                }
+
+                // run promises sequentially with reduce
+                return promises.reduce(function (promise, f) {
+                    return promise.then(f);
+                }, Q());
+            });
+
+            it("returns a successful response", function () {
+                return list().then(function (response) {
+                    expect(response.body.success).to.equal(true);
+                });
+            });
+
+            it("returns the correct count", function () {
+                return list().then(function (response) {
+                    expect(response.body.count).to.equal(40);
+                });
+            });
+
+            describe("with limit parameter", function () {
+                it("limits results to 25 by default", function () {
+                    return list().then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                        expect(response.body.formularyEntries.length).to.equal(25);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
+                it("lets us limit the results to less than 25", function () {
+                    return list({ limit: 15 }).then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                        expect(response.body.formularyEntries.length).to.equal(15);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
+                it("lets us limit the results to between 25 and 40", function () {
+                    return list({ limit: 30 }).then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                        expect(response.body.formularyEntries.length).to.equal(30);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
+                it("lets us limit the results to greater than 40, but caps at 40", function () {
+                    return list({ limit: 50 }).then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                        expect(response.body.formularyEntries.length).to.equal(40);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
+                it("ignores a null limit parameter", function () {
+                    return list({ limit: null }).then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                        expect(response.body.formularyEntries.length).to.equal(25);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
+                it("allows a zero limit parameter to return all results", function () {
+                    return list({ limit: 0 }).then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                        expect(response.body.formularyEntries.length).to.equal(40);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
+                it("rejects an invalid limit parameter", function () {
+                    return expect(list({ limit: "foo" })).to.be.an.api.error(400, "invalid_limit");
+                });
+            });
+
+            describe("with offset parameter", function () {
+                it("defaults to an offset of 0", function () {
+                    return list().then(function (defResponse) {
+                        return list({ offset: 0 }).then(function (response) {
+                            expect(response.body.success).to.equal(true);
+                            expect(defResponse.body).to.deep.equal(response.body);
+                        });
+                    });
+                });
+
+                it("lets us specify a valid offset", function () {
+                    return list().then(function (defResponse) {
+                        return list({ offset: 5 }).then(function (response) {
+                            expect(response.body.success).to.equal(true);
+                            expect(response.body.count).to.equal(40);
+                            expect(response.body.formularyEntries.length).to.equal(25);
+
+                            var offsetResults = response.body.formularyEntries.slice(0, 20);
+                            var defaultResults = defResponse.body.formularyEntries.slice(5);
+                            expect(offsetResults).to.deep.equal(defaultResults);
+                        });
+                    });
+                });
+
+                it("lets us specify a valid offset that means less results are returned", function () {
+                    return list().then(function (defResponse) {
+                        return list({ offset: 20 }).then(function (response) {
+                            expect(response.body.success).to.equal(true);
+                            expect(response.body.count).to.equal(40);
+                            expect(response.body.formularyEntries.length).to.equal(20);
+
+                            var offsetResults = response.body.formularyEntries.slice(0, 5);
+                            var defaultResults = defResponse.body.formularyEntries.slice(20);
+                            expect(offsetResults).to.deep.equal(defaultResults);
+                        });
+                    });
+                });
+
+                it("lets us specify a valid offset that means no results are returned", function () {
+                    return list({ offset: 45 }).then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                        expect(response.body.count).to.equal(40);
+                        expect(response.body.formularyEntries.length).to.equal(0);
+                    });
+                });
+                it("lets us specify both an offset and limit parameter", function () {
+                    return list().then(function (defResponse) {
+                        return list({ offset: 5, limit: 5 }).then(function (response) {
+                            expect(response.body.success).to.equal(true);
+                            expect(response.body.count).to.equal(40);
+                            expect(response.body.formularyEntries.length).to.equal(5);
+
+                            var offsetResults = response.body.formularyEntries.slice(0, 5);
+                            var defaultResults = defResponse.body.formularyEntries.slice(5, 10);
+                            expect(offsetResults).to.deep.equal(defaultResults);
+                        });
+                    });
+                });
+
+                it("ignores a null offset", function () {
+                    return list().then(function (defResponse) {
+                        return list({ offset: null }).then(function (response) {
+                            expect(response.body.success).to.equal(true);
+                            expect(defResponse.body).to.deep.equal(response.body);
+                        });
+                    });
+                });
+
+                it("rejects an invalid offset parameter", function () {
+                    return expect(list({ offset: "foo" })).to.be.an.api.error(400, "invalid_offset");
+                });
+            });
+
+            describe("with sort_by parameter", function () {
+                it("defaults to sorting by id", function () {
+                    return list().then(function (response) {
+                        expect(response.body.success).to.equal(true);
+
+                        var sorted = response.body.formularyEntries.slice(0).sort(function (userA, userB) {
+                            // string IDs
+                            return userA.id.localeCompare(userB.id);
+                        });
+                        expect(response.body.formularyEntries).to.deep.equal(sorted);
+                    });
+                });
+
+                it("allows sorting by id", function () {
+                    return list({ sort_by: "id" }).then(function (response) {
+                        expect(response.body.success).to.equal(true);
+
+                        var sorted = response.body.formularyEntries.slice(0).sort(function (userA, userB) {
+                            // string IDs
+                            return userA.id.localeCompare(userB.id);
+                        });
+                        expect(response.body.formularyEntries).to.deep.equal(sorted);
+                    });
+                });
+
+                it("ignores a null sort_by", function () {
+                    return list({ sort_by: null }).then(function (response) {
+                        expect(response.body.success).to.equal(true);
+
+                        var sorted = response.body.formularyEntries.slice(0).sort(function (userA, userB) {
+                            // string IDs
+                            return userA.id.localeCompare(userB.id);
+                        });
+                        expect(response.body.formularyEntries).to.deep.equal(sorted);
+                    });
+                });
+
+                it("rejects an invalid sort_by", function () {
+                    return expect(list({ sort_by: "foo" })).to.be.an.api.error(400, "invalid_sort_by");
+                });
+            });
+
+            describe("with sort_order parameter", function () {
+                it("defaults to sorting in ascending order", function () {
+                    return list().then(function (defResponse) {
+                        return list({ sort_order: "asc" }).then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                            expect(response.body).to.deep.equal(defResponse.body);
+                        });
+                    });
+                });
+
+                it("allows sorting in ascending order", function () {
+                    return list({ sort_order: "asc" }).then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                        var sorted = response.body.formularyEntries.slice(0).sort(function (userA, userB) {
+                            // string IDs
+                            return userA.id.localeCompare(userB.id);
+                        });
+                        expect(response.body.formularyEntries).to.deep.equal(sorted);
+                    });
+                });
+
+                it("allows sorting in descending order", function () {
+                    return list({ sort_order: "desc" }).then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                        var sorted = response.body.formularyEntries.slice(0).sort(function (userA, userB) {
+                            // string IDs
+                            return userA.id.localeCompare(userB.id);
+                        }).reverse();
+                        expect(response.body.formularyEntries).to.deep.equal(sorted);
+                    });
+                });
+
+                it("allows both sort_by and sort_order", function () {
+                    return list({ sort_order: "desc", sort_by: "id" }).then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                        var sorted = response.body.formularyEntries.slice(0).sort(function (userA, userB) {
+                            // string IDs
+                            return userA.id.localeCompare(userB.id);
+                        }).reverse();
+                        expect(response.body.formularyEntries).to.deep.equal(sorted);
+                    });
+                });
+
+                it("ignores a null sort_order", function () {
+                    return list().then(function (defResponse) {
+                        return list({ sort_order: null }).then(function (response) {
+                            expect(response.body.success).to.equal(true);
+                            expect(response.body).to.deep.equal(defResponse.body);
+                        });
+                    });
+                });
+
+                it("rejects an invalid sort_order", function () {
+                    return expect(list({
+                        sort_order: "foo"
+                    })).to.be.an.api.error(400, "invalid_sort_order");
+                });
+            });
+
+            describe("with genericName parameter", function () {
+                it("doesn't filter by genericName by default", function () {
+                    return list().then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
+                it("ignores a null genericName parameter", function () {
+                    return list({ genericName: null }).then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
+                it("handles no results", function () {
+                    return list({ genericName: "notanamelikethis" }).then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                        expect(response.body.count).to.equal(0);
+                        expect(response.body.formularyEntries.length).to.equal(0);
+                    });
+                });
+
+                it("handles searching substring", function () {
+                    return list({ genericName: "matching" }).then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                        expect(response.body.count).to.equal(1);
+                        expect(response.body.formularyEntries.length).to.equal(1);
+                        expect(response.body.formularyEntries[0].genericName).to.equal("test substring matching");
+                    });
+                });
+            });
+
+            describe("with vaClass parameter", function () {
+                it("doesn't filter by vaClass by default", function () {
+                    return list().then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
+                it("ignores a null vaClass parameter", function () {
+                    return list({ vaClass: null }).then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                        expect(response.body.count).to.equal(40);
+                    });
+                });
+
+                it("handles no results", function () {
+                    return list({ vaClass: "notanamelikethis" }).then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                        expect(response.body.count).to.equal(0);
+                        expect(response.body.formularyEntries.length).to.equal(0);
+                    });
+                });
+
+                it("handles searching exactly", function () {
+                    return list({ vaClass: "YZ999" }).then(function (response) {
+                        expect(response.body.success).to.equal(true);
+                        expect(response.body.count).to.equal(1);
+                        expect(response.body.formularyEntries.length).to.equal(1);
+                        expect(response.body.formularyEntries[0].vaClass).to.equal("YZ999");
+                    });
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
# What does this do?
Two things
1. Introduces a script for importing VA Formulary data from a spreadsheet and inserting it into mongodb. The excel sheet located here (https://www.pbm.va.gov/PBM/nationalformulary/VANF-October_2018.xls) was used for developing the script.
    * The script was developed with the assumption that the general format of the excel sheet won't change in specific ways.
2. Adds an endpoint for searching through this new collection of the va formulary entries

# How do I test it?
* run the script with the file linked to above as the only argument. Check mongo to make sure the entries got added.
* using postman, GET /formulary/search?genericName=SEARCH_TERM_HERE
  * try searching for different entries that you see in the spreadsheet