### PR TITLE
only programAministrators can see all patients

### DIFF
--- a/lib/controllers/patients/core.js
+++ b/lib/controllers/patients/core.js
@@ -70,8 +70,8 @@ patients.get("/", auth.authenticate, paramParser, function (req, res, next) {
         creator: req.listParameters.filters.creator
     };
 
-    // clinicians get access to all patient data
-    if (req.user.role === "clinician")
+    // program admins get access to all patient data
+    if (req.user.role === "programAdministrator")
         // the model handles the querying for us
         return Patient.findForClinician(params, req.user, returnListData(res, next));
     else


### PR DESCRIPTION
clinicians no longer get the list of all patients - only ones that have been shared with them.
Test by creating a clinician and GET /patients. You will only see the patient object associated with the clinician making the request, because no patients have been shared with them yet.