### PR TITLE
hotfix/orange-972-obfuscate-notification-bodies

### DIFF
--- a/lib/models/patient/resources.js
+++ b/lib/models/patient/resources.js
@@ -49,7 +49,8 @@ module.exports = function (PatientSchema) {
                     creator.sendPushNotification({
                         notificationType: "NEW_MEDICATION_ADDED",
                         title: "New Medication Added",
-                        body: `${resource.name}, a new medication, has been added to your record`
+                        // body: `${resource.name}, a new medication, has been added to your record` // TODO ARH: After legal consult, potentially change the body back to this.
+                        body: "Your record has been updated."
                     });
                   });
                 }
@@ -148,7 +149,8 @@ module.exports = function (PatientSchema) {
                                 creator.sendPushNotification({
                                     notificationType: "MEDICATION_SCHEDULE_UPDATED",
                                     title: "Medication Schedule Updated",
-                                    body: `Your schedule for ${resource.name} has been changed`
+                                    // body: `Your schedule for ${resource.name} has been changed` // TODO ARH: After legal consult, potentially change the body back to this.
+                                    body: "Your record has been updated."
                                 });
                               });
                             }

--- a/lib/models/patient/resources.js
+++ b/lib/models/patient/resources.js
@@ -48,8 +48,10 @@ module.exports = function (PatientSchema) {
                   this.getCreator().then((creator) => {
                     creator.sendPushNotification({
                         notificationType: "NEW_MEDICATION_ADDED",
-                        title: "New Medication Added",
-                        // body: `${resource.name}, a new medication, has been added to your record` // TODO ARH: After legal consult, potentially change the body back to this.
+                        // TODO ARH: After legal consult, potentially change the title and body back to these.
+                        // title: "New Medication Added",
+                        // body: `${resource.name}, a new medication, has been added to your record`
+                        title: "Notification:",
                         body: "Your record has been updated."
                     });
                   });
@@ -148,8 +150,10 @@ module.exports = function (PatientSchema) {
                               this.getCreator().then((creator) => {
                                 creator.sendPushNotification({
                                     notificationType: "MEDICATION_SCHEDULE_UPDATED",
-                                    title: "Medication Schedule Updated",
-                                    // body: `Your schedule for ${resource.name} has been changed` // TODO ARH: After legal consult, potentially change the body back to this.
+                                    // TODO ARH: After legal consult, potentially change the title and body back to these.
+                                    // title: "Medication Schedule Updated",
+                                    // body: `Your schedule for ${resource.name} has been changed`
+                                    title: "Notification:",
                                     body: "Your record has been updated."
                                 });
                               });

--- a/lib/models/user/requests.js
+++ b/lib/models/user/requests.js
@@ -67,7 +67,8 @@ module.exports = function(UserSchema) {
                         }
                     });
                     const fullName = this.firstName + " " + this.lastName;
-                    const pushMessage = `${fullName} has requested access to your record`;
+                    // const pushMessage = `${fullName} has requested access to your record`; // TODO ARH: After legal consult, potentially change the body back to this.
+                    const pushMessage = "Someone has requested access to your record.";
                     user.sendPushNotification({
                         notificationType: "NEW_REQUEST",
                         title: "New Request",
@@ -201,7 +202,8 @@ module.exports = function(UserSchema) {
                 user.sendPushNotification({
                     notificationType: "REQUEST_APPROVED",
                     title: "Request Approved",
-                    body: `${fullName} has approved your request for access to their record`
+                    // body: `${fullName} has approved your request for access to their record` // TODO ARH: After legal consult, potentially change the body back to this.
+                    body: "Someone has approved your access request."
                 });
 
                 callback(null, request);

--- a/lib/models/user/requests.js
+++ b/lib/models/user/requests.js
@@ -71,7 +71,8 @@ module.exports = function(UserSchema) {
                     const pushMessage = "Someone has requested access to your record.";
                     user.sendPushNotification({
                         notificationType: "NEW_REQUEST",
-                        title: "New Request",
+                        // title: "New Request", // TODO ARH: After legal consult, potentially change the title back to this.
+                        title: "Notification:",
                         body: pushMessage
                     });
                     callback(null, request);
@@ -201,8 +202,10 @@ module.exports = function(UserSchema) {
                 const fullName = this.firstName + " " + this.lastName;
                 user.sendPushNotification({
                     notificationType: "REQUEST_APPROVED",
-                    title: "Request Approved",
-                    // body: `${fullName} has approved your request for access to their record` // TODO ARH: After legal consult, potentially change the body back to this.
+                    // TODO ARH: After legal consult, potentially change title and body back to these.
+                    // title: "Request Approved",
+                    // body: `${fullName} has approved your request for access to their record`
+                    title: "Notification:",
                     body: "Someone has approved your access request."
                 });
 


### PR DESCRIPTION
See https://jira.amida.com/browse/ORANGE-972

The notifications titles (in **bold**) and bodies are now:
- New medication added: "**Notification:** Your record has been updated."
- Medication schedule updated: "**Notification:** Your record has been updated."
- Log sharing requested: "**Notification:** Someone has requested access to your record."
- Log sharing request approved: "**Notification:** Someone has approved your access request.
- The messages-related one in the jira ticket is handled by the messaging service.

To test: Setup push notifications and try these types.