### PR TITLE
updated default patient when update user

### DIFF
--- a/lib/models/user/user.js
+++ b/lib/models/user/user.js
@@ -107,6 +107,20 @@ module.exports = function (gfs) {
         }
     });
 
+    // when updating a user, update the default patient as well
+    UserSchema.pre("save", function (next) {
+        if (!this.isNew) {
+            mongoose.model("Patient").findOne({ creator: this.email, me: true }).exec().then((patient) => {
+                patient.firstName = this.firstName;
+                patient.lastName = this.lastName;
+                patient.phone = this.phone;
+                patient.save().then(() => next());
+            });
+        } else {
+            next();
+        }
+    });
+
     // when creating a new user, send them an email as well
     UserSchema.pre("save", function (next) {
         if (this.isNew) {


### PR DESCRIPTION
# what does this do
this updates the default patient first name, last name, and phone number, when you update the user first name, last name, and phone number. This prevents the two from getting out of sync which could lead to confusing UI.
See ORANGE-1008

# how to test
* PUT /user { "first_name": "new first name", "last_name": "new last name", "phone": "5555555555" }
* GET /user
   * verify it comes back with updated information
* GET /patients
   * verify the patient corresponding to the user also has the updated information