### PR TITLE
giving admins a user when they first use orange-api

### DIFF
--- a/lib/controllers/helpers/passport.js
+++ b/lib/controllers/helpers/passport.js
@@ -32,10 +32,19 @@ module.exports = function() {
           done(null, user);
         } else {
           // **** SPECIAL CASE ****
-          // Admin is allowed through even though they dont have an orange
-          // user so that they can use the create user endpoint.
+          // The first admin to exist only exists on the auth service, but will need a
+          // user on orange as well. So if the user is "admin" and doesn't have a user
+          // in mongo, we create one for them.
           if (payload.scopes.includes("admin")) {
-            done(null, true);
+            User.create({
+              email: payload.email,
+              firstName: "System",
+              lastName: "Administrator",
+              role: "admin"
+            }).then((user) => {
+              req.user = user;
+              done(null, user);
+            }).catch((err) => done(err, false));
           } else {
             done(null, false);
           }

--- a/lib/models/user/user.js
+++ b/lib/models/user/user.js
@@ -45,7 +45,7 @@ module.exports = function (gfs) {
         role: {
             type: String,
             enum: {
-                values: ["user", "clinician", "programAdministrator", "instructor"],
+                values: ["user", "clinician", "programAdministrator", "instructor", "admin"],
                 message: "INVALID_ROLE"
             },
             required: "INVALID_ROLE",


### PR DESCRIPTION
# what does this do?
The first `admin` is created during initial startup of auth-service and doesn't have an orange account.
With this PR, when a user with scope `admin` uses the orange-api and they don't have an orange user in mongo, then we make a user doc for them with some default info.
This is good because we need `admins` to be able to log into orange-web in order to create `programAdministrators`. This is already possible, but if the `admin` doesn't have an orange user, the UI looks blank and hardly works because the orange-api wont be able to return anything.

# how to test?
* Create a user with scope `admin` on the auth service.
* with a token for that user, GET `/v1/user`
  * this should return a user object with default info
