### PR TITLE
allow helpDesk users to see ALL medications

### DIFF
--- a/lib/models/medication.js
+++ b/lib/models/medication.js
@@ -318,8 +318,8 @@ MedicationSchema.methods.authorize = function (access, user, patient) {
     // access must be either read of write
     if (access !== "write" && access !== "read") return errors.INVALID_ACCESS;
 
-    // clinicians get full read access
-    if (user.role === "clinician" && access === "read") return null;
+    // clinicians and helpDesk get full read access
+    if ((user.role === "clinician" || user.role === "helpDesk") && access === "read") return null;
 
     // find the share between the user and patient
     var share = patient.shareForEmail(user.email);


### PR DESCRIPTION
Allows helpDesk users to see ALL medications.

Test by logging in as a help desk user, and viewing the medications of a patient. If you can do this, then this works!