### PR TITLE
adherence log on orange-clinical uses the dump api so helpDesk needs access

### DIFF
--- a/lib/controllers/patients/dump.js
+++ b/lib/controllers/patients/dump.js
@@ -8,7 +8,7 @@ const guard = auth.roleGuard;
 var dump = module.exports = express.Router({ mergeParams: true });
 
 // View JSON dump of all patient data the user has access to
-dump.get("/", auth.authenticate, guard(["admin", "programAdministrator", "clinician"]), auth.authorize("read"), function (req, res, next) {
+dump.get("/", auth.authenticate, guard(["admin", "programAdministrator", "clinician", "helpDesk"]), auth.authorize("read"), function (req, res, next) {
     generateDump(req.patient, req.user, req.query.start_date, req.query.end_date, function (err, results) {
         if (err) return next(err);
 


### PR DESCRIPTION
All in the title.

To test:
Log in as a help instructor
View a patients adherence log.
It should show things (assuming there are things to show).