### PR TITLE
adherence log on orange-clinical uses the dump api so helpDesk needs …

### DIFF
--- a/lib/controllers/patients/dump.js
+++ b/lib/controllers/patients/dump.js
@@ -8,7 +8,7 @@ const guard = auth.roleGuard;
 var dump = module.exports = express.Router({ mergeParams: true });
 
 // View JSON dump of all patient data the user has access to
-dump.get("/", auth.authenticate, guard(["admin", "programAdministrator", "clinician"]), auth.authorize("read"), function (req, res, next) {
+dump.get("/", auth.authenticate, guard(["admin", "programAdministrator", "clinician", "helpDesk"]), auth.authorize("read"), function (req, res, next) {
     generateDump(req.patient, req.user, req.query.start_date, req.query.end_date, function (err, results) {
         if (err) return next(err);
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Amida",
   "name": "orange-api",
   "description": "API for Orange medication adherance apps",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "repository": {
     "type": "git",
     "url": "git@github.com:amida-tech/orange-api.git"


### PR DESCRIPTION
**The original PR for this fix was closed (https://github.com/amida-tech/orange-api/pull/139) and is replaced by this PR.**

## From the original PR:

All in the title.

To test:
Log in as a help instructor
View a patients adherence log.
It should show things (assuming there are things to show).