### PR TITLE
remove crashing log statement, reformatting

### DIFF
--- a/lib/controllers/journal.js
+++ b/lib/controllers/journal.js
@@ -110,39 +110,25 @@ function setRole(req, res, next) {
 }
 
 function notesMoodsSideEffects (req, res, next) {
-  var q = mongoose.model("Patient").findById(req.patient._id);
-
-  console.log("this is frustrating");
-  q.exec(function (err, patient) {
-    if (err) {
-      return next(errors.FETCHING_JOURNAL_ENTRIES_FAILED);
-    }
-
     var results = [];
     if (req.route.path === "/notes") {
-      results = patient.entries.filter(function (entry) {
-        return !!entry.text;
-      });
+        results = req.patient.entries.filter(function (entry) {
+            return !!entry.text;
+        });
+    } else if (req.route.path === "/side-effects") {
+        results = req.patient.entries.filter(function (entry) {
+            return !!entry.sideEffect;
+        });
+    } else if (req.route.path === "/moods") {
+        results = req.patient.entries.filter(function (entry) {
+            return !!entry.mood;
+        });
     }
-    else if (req.route.path === "/side-effects") {
-      results = patient.entries.filter(function (entry) {
-        return !!entry.sideEffect;
-      });
-    }
-    else if (req.route.path === "/moods") {
-      results = patient.entries.filter(function (entry) {
-        return !!entry.mood;
-      });
-    }
-
-    winstonInstance.debug({message: `journal.get(${req.route.path})`, results: results});
-
     res.status(200).send({
-      count: results.length,
-      success: true,
-      entries: results
+        count: results.length,
+        success: true,
+        entries: results
     });
-  });
 }
 
 journal.get("/notes", guard(["admin", "programAdministrator", "clinician", "helpDesk"]), auth.authorize("read"), notesMoodsSideEffects);


### PR DESCRIPTION
# Related Tickets
- [ORANGE-1133](https://jira.amida-tech.com/browse/ORANGE-1133)

# Other Repos' PR(s) Intended to Work With This PR
None.

# How Things Worked (or Didn't) Before This PR
<!-- You may say "See Jira Ticket X" if the Jira ticket has this info -->
See Jira.

Crashed on GET to /patients/:patientId/journal/notes

# How Things Works Now 
<!-- Include test setup, testing steps, and expected results -->
<!-- You may say "See Jira Ticket X" if the Jira ticket has this info -->
Doesn't crash on GET to /patients/:patientId/journal/notes

The issue causing the crash seemed to be that winston was trying to access something on the Mongo Array `results` that didn't exist. I removed the logging statement. If we need this logging statement in some form, let me know and I'll add back something equivalent.

I also cleaned up the formatting of the `notesMoodsSideEffects` function to match the rest of the codebase.

# Readiness
<!--- Check all that apply, please provide context when a condition cannot be met. -->
1. [ ] This PR has full test coverage (If this PR fixes a bug, you _must_ add test cases respresentative of the bug).
 - Willing to add a test if anyone can think of a way to test this
2. [ ] This PR passes all tests.
 - Several tests have been failing on orange-api for a while. See https://jira.amida.com/browse/ORANGE-1097
3. [x] This PR has no linting errors.
4. [x] This PR has no hardcoded UI strings or other obvious issues.
 - Meta comment: Not sure if checking for "other obvious issues" is helpful.
5. [x] This PR has been updated to include all changes from develop.
6. [x] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
 - NA
7. [x] This PR's required changes outside of the scope of this repository have been documented in this pull request.
 - NA
