### PR TITLE
revoke device token

### DIFF
--- a/lib/controllers/users.js
+++ b/lib/controllers/users.js
@@ -314,7 +314,7 @@ users.put("/", authenticate, function (req, res, next) {
           return next(err);
         } else if (httpResponse.statusCode !== 200) {
           res.status(httpResponse.statusCode);
-          return next(errors.UNKNOWN_ERROR);
+          return next(errors.AUTH_SERVICE_ERROR);
         }
 
         //Create device on Notification Microservice using Microservice user Credentials
@@ -335,7 +335,7 @@ users.put("/", authenticate, function (req, res, next) {
             return next(err);
           } else if (httpResponse.statusCode !== 200) {
             res.status(httpResponse.statusCode);
-            return next(errors.UNKNOWN_ERROR);
+            return next(errors.NOTIFICATION_SERVICE_ERROR);
           }
         });
       });
@@ -361,59 +361,12 @@ users.put("/", authenticate, function (req, res, next) {
 });
 
 users.delete("/revoke-device", authenticate, function (req, res, next) {
-    const revokeDeviceOnNMS = (token, deviceType) => {
-      request.post({
-        url: `${config.authServiceAPI}/auth/login`,
-        body: {
-          username: config.pushNotificationsServiceUserUsername,
-          password: config.pushNotificationsServiceUserPassword
-        },
-        json: true,
-        headers: {
-          "Content-Type" : "application/json"
-        }
-      }, function(err, httpResponse){
-        if (err) {
-          return next(err);
-        } else if (httpResponse.statusCode !== 200) {
-          res.status(httpResponse.statusCode);
-          return next(errors.UNKNOWN_ERROR);
-        }
-
-        request.delete({
-          url: `${config.notificationServiceAPI}/users/revoke-device`,
-          form: {
-            username: req.user.email,
-            token,
-            deviceType
-          },
-          headers: {
-            Authorization: "Bearer " + httpResponse.body.token,
-            "Content-Type": "application/json"
-          },
-          json: true
-        }, function(err, httpResponse){
-          if (err) {
-            return next(err);
-          } else if (httpResponse.statusCode !== 200) {
-            res.status(httpResponse.statusCode);
-            return next(errors.UNKNOWN_ERROR);
-          }
-          res.status(200);
-          res.send({
-              success: true
-          });
-        });
-      });
-    };
-
-
     const deviceToken = req.query.deviceToken;
     const gcmToken = req.query.gcmToken;
     if (typeof deviceToken !== "undefined" && config.pushNotificationsEnabled) {
-      revokeDeviceOnNMS(deviceToken, "iOS");
+      revokeDeviceOnNMS(deviceToken, "iOS", req, res, next);
     } else if (typeof gcmToken !== "undefined" && config.pushNotificationsEnabled) {
-      revokeDeviceOnNMS(gcmToken, "Android");
+      revokeDeviceOnNMS(gcmToken, "Android", req, res, next);
     } else {
       next(errors.INVALID_SUBMISSION);
     }
@@ -505,3 +458,49 @@ users.get("/:email/avatar(.\\w+)?", authenticate, function (req, res, next) {
         }
     });
 });
+
+function revokeDeviceOnNMS(token, deviceType, req, res, next) {
+    request.post({
+        url: `${config.authServiceAPI}/auth/login`,
+        body: {
+            username: config.pushNotificationsServiceUserUsername,
+            password: config.pushNotificationsServiceUserPassword
+        },
+        json: true,
+        headers: {
+            "Content-Type" : "application/json"
+        }
+    }, function(err, httpResponse){
+        if (err) {
+            return next(err);
+        } else if (httpResponse.statusCode !== 200) {
+            res.status(httpResponse.statusCode);
+            return next(errors.AUTH_SERVICE_ERROR);
+        }
+
+        request.delete({
+            url: `${config.notificationServiceAPI}/users/revoke-device`,
+            form: {
+                username: req.user.email,
+                token,
+                deviceType
+            },
+            headers: {
+                Authorization: "Bearer " + httpResponse.body.token,
+                "Content-Type": "application/json"
+            },
+            json: true
+        }, function(err, httpResponse){
+                if (err) {
+                    return next(err);
+                } else if (httpResponse.statusCode !== 200) {
+                    res.status(httpResponse.statusCode);
+                    return next(errors.NOTIFICATION_SERVICE_ERROR);
+                }
+                res.status(200);
+                res.send({
+                    success: true
+                });
+        });
+    });
+};

--- a/lib/controllers/users.js
+++ b/lib/controllers/users.js
@@ -416,10 +416,10 @@ users.delete("/revoke-device", authenticate, function (req, res, next) {
     const gcmToken = req.query.gcmToken;
     if (typeof deviceToken !== "undefined" && config.pushNotificationsEnabled) {
       revokeDeviceOnNMS(deviceToken, "iOS");
-    }
-
-    if (typeof gcmToken !== "undefined" && config.pushNotificationsEnabled) {
+    } else if (typeof gcmToken !== "undefined" && config.pushNotificationsEnabled) {
       revokeDeviceOnNMS(gcmToken, "Android");
+    } else {
+      next(errors.INVALID_SUBMISSION);
     }
 });
 

--- a/lib/controllers/users.js
+++ b/lib/controllers/users.js
@@ -17,8 +17,8 @@ var users = module.exports = express.Router({ mergeParams: true });
 var User = mongoose.model("User");
 var Patient = mongoose.model("Patient");
 
-const makeRequest = (data, callback) => {
-  request.post(data, callback);
+const makeRequest = (data, callback, method = "post") => {
+  request[method](data, callback);
 };
 
 // Add UUID for users that do not already have one on their account
@@ -364,7 +364,7 @@ users.put("/", authenticate, function (req, res, next) {
     });
 });
 
-users.put("/revoke-device", authenticate, function (req, res, next) {
+users.delete("/revoke-device", authenticate, function (req, res, next) {
     const revokeDeviceOnNMS = (token, deviceType) => {
       makeRequest({
         url: `${config.authServiceAPI}/auth/login`,
@@ -407,11 +407,13 @@ users.put("/revoke-device", authenticate, function (req, res, next) {
           res.send({
               success: true
           });
-        });
+        }, "delete");
       });
     };
-    const deviceToken = req.body.deviceToken;
-    const gcmToken = req.body.gcmToken;
+
+
+    const deviceToken = req.query.deviceToken;
+    const gcmToken = req.query.gcmToken;
     if (typeof deviceToken !== "undefined" && config.pushNotificationsEnabled) {
       revokeDeviceOnNMS(deviceToken, "iOS");
     }

--- a/lib/controllers/users.js
+++ b/lib/controllers/users.js
@@ -17,10 +17,6 @@ var users = module.exports = express.Router({ mergeParams: true });
 var User = mongoose.model("User");
 var Patient = mongoose.model("Patient");
 
-const makeRequest = (data, callback, method = "post") => {
-  request[method](data, callback);
-};
-
 // Add UUID for users that do not already have one on their account
 User.find({ "uuid" : { "$exists" : false } }, function(err, users) {
     if (err) {
@@ -184,7 +180,7 @@ users.post("/", ...maybeAuthenticate, function (req, res, next) {
             var reqBody = req.body;
             reqBody.username = reqBody.email;
             reqBody.scopes = [reqBody.role];
-            makeRequest({
+            request.post({
                 url: `${config.authServiceAPI}/user`,
                 headers: {
                     authorization: req.headers.authorization
@@ -204,7 +200,7 @@ users.post("/", ...maybeAuthenticate, function (req, res, next) {
                 if (config.pushNotificationsEnabled) {
 
                     //Login as microservice user on auth service
-                    makeRequest({
+                    request.post({
                         url: `${config.authServiceAPI}/auth/login`,
                         body: {
                             username: config.pushNotificationsServiceUserUsername,
@@ -223,7 +219,7 @@ users.post("/", ...maybeAuthenticate, function (req, res, next) {
                         }
 
                         //Create user on Notification Microservice using Microservice user Credentials
-                        makeRequest({
+                        request.post({
                             url: `${config.notificationServiceAPI}/users`,
                             form: {
                                 username: req.body.username,
@@ -303,7 +299,7 @@ users.put("/", authenticate, function (req, res, next) {
     if (typeof phone !== "undefined") req.user.phone = phone;
 
     const updateTokenOnNMS = (token, deviceType) => {
-      makeRequest({
+      request.post({
         url: `${config.authServiceAPI}/auth/login`,
         body: {
           username: config.pushNotificationsServiceUserUsername,
@@ -322,7 +318,7 @@ users.put("/", authenticate, function (req, res, next) {
         }
 
         //Create device on Notification Microservice using Microservice user Credentials
-        makeRequest({
+        request.post({
           url: `${config.notificationServiceAPI}/users/updateDevice`,
           form: {
             username: req.user.email,
@@ -366,7 +362,7 @@ users.put("/", authenticate, function (req, res, next) {
 
 users.delete("/revoke-device", authenticate, function (req, res, next) {
     const revokeDeviceOnNMS = (token, deviceType) => {
-      makeRequest({
+      request.post({
         url: `${config.authServiceAPI}/auth/login`,
         body: {
           username: config.pushNotificationsServiceUserUsername,
@@ -384,7 +380,7 @@ users.delete("/revoke-device", authenticate, function (req, res, next) {
           return next(errors.UNKNOWN_ERROR);
         }
 
-        makeRequest({
+        request.delete({
           url: `${config.notificationServiceAPI}/users/revoke-device`,
           form: {
             username: req.user.email,
@@ -407,7 +403,7 @@ users.delete("/revoke-device", authenticate, function (req, res, next) {
           res.send({
               success: true
           });
-        }, "delete");
+        });
       });
     };
 

--- a/lib/controllers/users.js
+++ b/lib/controllers/users.js
@@ -345,14 +345,12 @@ users.put("/", authenticate, function (req, res, next) {
       });
     };
 
-    if (typeof deviceToken !== "undefined") {
-      req.user.deviceToken = deviceToken;
-      if (config.pushNotificationsEnabled) updateTokenOnNMS(deviceToken, "iOS");
+    if (typeof deviceToken !== "undefined" && config.pushNotificationsEnabled) {
+      updateTokenOnNMS(deviceToken, "iOS");
     }
 
-    if (typeof gcmToken !== "undefined") {
-      req.user.gcmToken = gcmToken;
-      if (config.pushNotificationsEnabled) updateTokenOnNMS(gcmToken, "Android");
+    if (typeof gcmToken !== "undefined" && config.pushNotificationsEnabled) {
+      updateTokenOnNMS(gcmToken, "Android");
     }
 
     // npi is only a clinician field
@@ -364,6 +362,63 @@ users.put("/", authenticate, function (req, res, next) {
         // successful response
         res.send(createSuccessfulUserResponse(req.user));
     });
+});
+
+users.put("/revoke-device", authenticate, function (req, res, next) {
+    const revokeDeviceOnNMS = (token, deviceType) => {
+      makeRequest({
+        url: `${config.authServiceAPI}/auth/login`,
+        body: {
+          username: config.pushNotificationsServiceUserUsername,
+          password: config.pushNotificationsServiceUserPassword
+        },
+        json: true,
+        headers: {
+          "Content-Type" : "application/json"
+        }
+      }, function(err, httpResponse){
+        if (err) {
+          return next(err);
+        } else if (httpResponse.statusCode !== 200) {
+          res.status(httpResponse.statusCode);
+          return next(errors.UNKNOWN_ERROR);
+        }
+
+        makeRequest({
+          url: `${config.notificationServiceAPI}/users/revoke-device`,
+          form: {
+            username: req.user.email,
+            token,
+            deviceType
+          },
+          headers: {
+            Authorization: "Bearer " + httpResponse.body.token,
+            "Content-Type": "application/json"
+          },
+          json: true
+        }, function(err, httpResponse){
+          if (err) {
+            return next(err);
+          } else if (httpResponse.statusCode !== 200) {
+            res.status(httpResponse.statusCode);
+            return next(errors.UNKNOWN_ERROR);
+          }
+          res.status(200);
+          res.send({
+              success: true
+          });
+        });
+      });
+    };
+    const deviceToken = req.body.deviceToken;
+    const gcmToken = req.body.gcmToken;
+    if (typeof deviceToken !== "undefined" && config.pushNotificationsEnabled) {
+      revokeDeviceOnNMS(deviceToken, "iOS");
+    }
+
+    if (typeof gcmToken !== "undefined" && config.pushNotificationsEnabled) {
+      revokeDeviceOnNMS(gcmToken, "Android");
+    }
 });
 
 // Delete user

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -185,6 +185,10 @@ module.exports = {
         INVALID_EVENT_ID: new APIError("invalid_event_id", 400),
 
         // Invalid fields and
-        INVALID_SUBMISSION: new APIError("invalid_submission", 400)
+        INVALID_SUBMISSION: new APIError("invalid_submission", 400),
+
+        // Microservice Errors
+        AUTH_SERVICE_ERROR: new APIError("auth_microservice_error", 500),
+        NOTIFICATION_SERVICE_ERROR: new APIError("notification_microservice_error", 500)
     }
 };


### PR DESCRIPTION
# Related Tickets
- [ORANGE-1029](https://jira.amida-tech.com/browse/ORANGE-1029)
Prevents notifications from being sent to signed out device
# Other Repos' PR(s) Intended to Work With This PR
https://github.com/amida-tech/amida-notification-microservice/pull/36
https://github.com/amida-tech/orange-ignite/pull/276

# How Things Worked (or Didn't) Before This PR
<!-- You may say "See Jira Ticket X" if the Jira ticket has this info -->
Notifications for specific users were being sent to a device after signing out from the device
# How Things Works Now 
<!-- Include test setup, testing steps, and expected results -->
<!-- You may say "See Jira Ticket X" if the Jira ticket has this info -->
You will need to have your notifications MS running with the PR provided above. Signing out from the ORange client should make a delete request to the OrangeAPI which is relayed to the notification microservice to delete the device corresponding to that token.

# Readiness
<!--- Check all that apply, please provide context when a condition cannot be met. -->
1. [ ] This PR has full test coverage (If this PR fixes a bug, you _must_ add test cases respresentative of the bug).
2. [ ] This PR passes all tests.
3. [ ] This PR has no linting errors.
4. [ ] This PR has no hardcoded UI strings or other obvious issues.
5. [ ] This PR has been updated to include all changes from develop.
6. [ ] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
7. [ ] This PR's required changes outside of the scope of this repository have been documented in this pull request.
<!--- Such as moving to a new branch on an API, modifying a table, running a script, etc. -->
<!--- If yes, please document the changes here. -->
