### PR TITLE
Removing cycle shifting in display field

### DIFF
--- a/lib/models/schedule/schedule.js
+++ b/lib/models/schedule/schedule.js
@@ -190,15 +190,6 @@ Schedule.prototype.toSummary = function (start, end, tz, extra, regularOnly) {
         additionalInfo += " (starting from ";
         this.cycleStarts.forEach(function(cycleStart) {
             cycleStart = moment.tz(cycleStart, "YYYY-MM-DD", tz).startOf("day");
-            var increment = this.frequency.n;
-            if (hasExcludes) increment *= freq.exclude.repeat;
-
-            while (cycleStart.isBefore(start)) {
-                cycleStart.add(increment, this.frequency.unit);
-            }
-            while (cycleStart.isAfter(start)) {
-                cycleStart.subtract(increment, this.frequency.unit);
-            }
             additionalInfo += cycleStart.format("M/D/YY");
         }.bind(this));
         additionalInfo += ")";


### PR DESCRIPTION
# Related Tickets
- [ORANGE-1114](https://jira.amida-tech.com/browse/ORANGE-1114)

# Other Repos' PR(s) Intended to Work With This PR

Front end piece
https://github.com/amida-tech/orange-web/pull/66

# How Things Worked (or Didn't) Before This PR
<!-- You may say "See Jira Ticket X" if the Jira ticket has this info -->

Changed the start date display to match with the cycle

# How Things Works Now 
<!-- Include test setup, testing steps, and expected results -->
<!-- You may say "See Jira Ticket X" if the Jira ticket has this info -->

Now just the date is not modified

# Readiness
<!--- Check all that apply, please provide context when a condition cannot be met. -->
1. [ ] This PR has full test coverage (If this PR fixes a bug, you _must_ add test cases respresentative of the bug).
2. [ ] This PR passes all tests.
3. [ ] This PR has no linting errors.
4. [ ] This PR has no hardcoded UI strings or other obvious issues.
5. [ ] This PR has been updated to include all changes from develop.
6. [ ] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
7. [ ] This PR's required changes outside of the scope of this repository have been documented in this pull request.
<!--- Such as moving to a new branch on an API, modifying a table, running a script, etc. -->
<!--- If yes, please document the changes here. -->
