### PR TITLE
[ORANGE-1183] Meditation Reminders Broke

### DIFF
--- a/lib/models/user/pushNotifications.js
+++ b/lib/models/user/pushNotifications.js
@@ -1,36 +1,52 @@
 "use strict";
 
 const config  = require("../../../config.js");
-const Client = require("node-rest-client").Client;
-const client = new Client();
+const request = require("request");
 
 module.exports = function (UserSchema) {
 
     UserSchema.methods.sendPushNotification = function (payload) {
-      if (!config.pushNotificationsEnabled) return;
-      var user = this;
+        if (!config.pushNotificationsEnabled) return;
+        var user = this;
 
-      const username = user.email;
-      const pushData = [
-        Object.assign({username, namespace: "OrangeMobile"}, payload)
-      ];
+        const username = user.email;
+        const pushData = [
+            Object.assign({username, namespace: "OrangeMobile"}, payload)
+        ];
 
-      const authArgs = {
-          headers: {"Content-Type": "application/json"},
-          data: {
-            username: config.pushNotificationsServiceUserUsername,
-            password: config.pushNotificationsServiceUserPassword
-          }
-      };
+        const authArgs = {
+            url: `${config.authServiceAPI}/auth/login`,
+            headers: { "Content-Type": "application/json" },
+            json: true,
+            body: {
+              username: config.pushNotificationsServiceUserUsername,
+              password: config.pushNotificationsServiceUserPassword
+            }
+        };
 
-      client.post(`${config.authServiceAPI}/auth/login`, authArgs, function (data, response) {
-          const { token } = data;
-          const pushNotificationArgs = {
-              headers: {"Content-Type": "application/json", "Authorization":"Bearer " + token},
-              data: {pushData}
-          };
-          client.post(`${config.notificationServiceAPI}/notifications/sendPushNotifications`, pushNotificationArgs, function (data, response) {
-          });
-      });
+        request.post(authArgs, function (err, res) {
+            if (err) {
+                console.log(`${new Date()} Error: pushNotifications.js: Push notificatios cron job call to Auth Service failed. Aborting.`, err);
+                return;
+            }
+
+            const { token } = res.body;
+            const pushNotificationArgs = {
+                url: `${config.notificationServiceAPI}/notifications/sendPushNotifications`,
+                headers: {
+                    "Content-Type": "application/json",
+                    "Authorization": "Bearer " + token
+                },
+                json: true,
+                body: { pushData }
+            };
+
+            request.post(pushNotificationArgs, function (err) {
+                if (err) {
+                    console.log(`${new Date()} Error: pushNotifications.js: Push notifications cron job call to Notification Service failed. Aborting.`, err);
+                    return;
+                }
+            });
+        });
     };
 };

--- a/scheduleReminderNotifications.js
+++ b/scheduleReminderNotifications.js
@@ -44,7 +44,6 @@ function sendMedicationReminder (patient, item, user) {
 function sendMeditationReminder(patient, user, date, time) {
     const key = `${patient._id}_${date}_${time}`
     checkIfSent(key).then((result) => {
-
         if (!result) {
             const notificationTitle = 'Meditation Reminder'
             const suffix = time === '11am' ? 'before noon' : 'this evening';
@@ -66,18 +65,19 @@ function sendReminders() {
     const startTimeISO = startTime.toISOString();
     const endTime = new Date(time + intervalInMilliseconds + bufferInMilliseconds);
     const endTimeISO = endTime.toISOString();
+
     User.find({ role: "user" }, function(err, users) {
         users.forEach((user) => {
             Patient.findOne({ creator: user.email, me: true }).exec().then((patient) => {
-                const startOfDay = moment().tz(patient.tz).startOf('day');
-                const today = startOfDay.format('YYYY-MM-DD');
-                const elevenAMInPatientTZ = moment(today).hours(11).toDate();
-                const sixPMInPatientTZ = moment(today).hours(18).toDate();
-                if (elevenAMInPatientTZ >= startTime && elevenAMInPatientTZ <= endTime) {
-                    sendMeditationReminder(patient, user, today, '11am')
+                const beginningOfTodayInPatientTz = moment().tz(patient.tz).startOf('day');
+                const elevenAmInPatientTz = moment(beginningOfTodayInPatientTz).hours(11);
+                const sixPmInPatientTz    = moment(beginningOfTodayInPatientTz).hours(18);
+
+                if (elevenAmInPatientTz >= startTime && elevenAmInPatientTz <= endTime) {
+                    sendMeditationReminder(patient, user, beginningOfTodayInPatientTz.format('YYYY-MM-DD'), '11am');
                 }
-                if (sixPMInPatientTZ >= startTime && sixPMInPatientTZ <= endTime) {
-                    sendMeditationReminder(patient, user, today, '6pm')
+                if (sixPmInPatientTz >= startTime && sixPmInPatientTz <= endTime) {
+                    sendMeditationReminder(patient, user, beginningOfTodayInPatientTz.format('YYYY-MM-DD'), '6pm')
                 }
                 patient.generateScheduleResults(startTimeISO, endTimeISO, user, null, user._id, function (err, items) {
                     if (err) return err;


### PR DESCRIPTION
# Related Tickets
<!-- If there is no Jira ticket for this PR, say why not. -->

https://jira.amida.com/browse/ORANGE-1183

# Other Repos' PR(s) Intended to Work With This PR

None.

# How Things Worked (or Didn't) Before This PR
<!-- You may say "See Jira Ticket X" if the Jira ticket has this info -->

See Jira ticket.

# How Things Work Now (And How to Test)
<!-- Include test setup, testing steps, and expected results -->
<!-- You may say "See Jira Ticket X" if the Jira ticket has this info -->

Meditation reminders calculate the time correctly and get sent at the correct time for both Android and iOS.

Setup your Orange API, Auth Service, and Notification Service with your Android sim locally.

After your services are running, login to your android sim in order to ensure your user's record in Mongo gets updated with the correct timezone.

In `scheduleReminderNotifications.js`, change the time of `elevenAmInPatientTz`. For example, if it's 5:28pm where you are, and you want to make this change and wait for the meditation reminder notifications to get triggered 3 minutes later, set it to this:

`const elevenAmInPatientTz = moment(beginningOfTodayInPatientTz).hours(17).minutes(31);`

Also, it will only send you a notification if it hasn't already. Therefore, to trick it into thinking it hasn't sent you this particular notification (to meditate on today's date at 11am), in `scheduleReminderNotifications.js` append an arbitrary string to the key as in blow:

```js
function sendMeditationReminder(patient, user, date, time) {
    const key = `${patient._id}_${date}_${time}_SOMETHING_ARBITRARY`
```

You should get a meditation reminder notification at 5:31 pm.

Note: I tested this on the dev servers and locally.

# Readiness
<!--- Check all that apply, please provide context when a condition cannot be met. -->
1. [N/A It's up to the original developer to add test cases] This PR has full test coverage (If this PR fixes a bug, you _must_ add test cases respresentative of the bug).
2. [x] This PR passes all automated tests.
3. [x] This PR has no linting errors.
4. [x] This PR has no hardcoded UI strings or other obvious issues.
5. [N/A] This PR has been updated to include all changes from develop.
6. [N/A] This PR's changes to configuration files have been documented in all appropriate places (such as but not limited to README.md), if applicable.
7. [N/A] This PR's required changes outside of the scope of this repository have been documented in this pull request.
<!--- Such as moving to a new branch on an API, modifying a table, running a script, etc. -->
<!--- If yes, please document the changes here. -->
