### PR TITLE
PR release/1.9.0 into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.9.0] -- 2019-05-16
+## [1.9.0] -- 2019-05-21
 ### Added
 - Environment variable `EMAIL_VERIFICATION_INIT_PAGE_URL`. See README for details.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Changelog
 
-## [Unreleased]
+## [1.9.0] -- 2019-05-16
 ### Added
 - Environment variable `EMAIL_VERIFICATION_INIT_PAGE_URL`. See README for details.
 
+### Removed
+- NPI implementation. The NPI library was broken, and the functionality was removed to make the automated tests work.
+
 ### Changed
 - HTTP status code is defaulted to 500 for errors that do not specify status codes.
+- Users of scope `admin` can now see patients.
+
+### Fixed
+- Mongo SSL config.
 
 ## [Prior to 1.9.0]
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Amida",
   "name": "orange-api",
   "description": "API for Orange medication adherance apps",
-  "version": "1.8.0",
+  "version": "1.9.0-rc.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:amida-tech/orange-api.git"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Amida",
   "name": "orange-api",
   "description": "API for Orange medication adherance apps",
-  "version": "1.9.0-rc.0",
+  "version": "1.9.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:amida-tech/orange-api.git"


### PR DESCRIPTION
Branch `release/1.9.0`, compared to `develop`, only has updates to CHANGELOG.md and the package.json version.